### PR TITLE
Use 'x-ms-client-name' for method name instead of 'operationId' if present

### DIFF
--- a/sdk/autorest/readme.md
+++ b/sdk/autorest/readme.md
@@ -66,16 +66,23 @@ directive:
           parameterName = v1Dynamic["value-path"];
         }
         if (operationId && parameterName) {
-          dynamicInputOperations[operationId] = true;
-          parameter.description = (parameter.description || "") + `\nYou can get this value by calling '${operationId}' and using the '${parameterName}' value).`;
+          dynamicInputOperations[operationId] = { 
+            parameter,
+            parameterName
+          };
         }
       }
       /* Iterate again to alter x-ms-visibility on operations themselves */
       for (const pathName in $.paths) {
         for (const methodName in $.paths[pathName]) {
           const action = $.paths[pathName][methodName];
-          if (dynamicInputOperations[action.operationId]) {
-            action["x-ms-visibility"] = action["x-ms-visibility"] + "-dynamic"
+          let dynamicInput = dynamicInputOperations[action.operationId];
+          if (dynamicInput && dynamicInput.parameter) {
+            action["x-ms-visibility"] = action["x-ms-visibility"] + "-dynamic";
+            /* Use x-ms-client-name if it's there */
+            let modifiedOperationId = action["x-ms-client-name"] || action.operationId;
+            /* Change description */
+            dynamicInput.parameter.description = (dynamicInput.parameter.description || "") + `\nYou can get this value by calling '${modifiedOperationId}' and using the '${dynamicInput.parameterName}' value).`;
           }
         }
       }
@@ -86,6 +93,12 @@ directive:
       if ($["x-ms-visibility"] === "internal") {
         return;
       }
+  # Use "x-ms-client-name" instead of "operationId" if it's there. 
+  # Note that references to "operationId" for dynamic values has been fixed above.
+  - from: swagger-document
+    where: $..[?(@.operationId)]
+    transform: >-
+      $.operationId = $["x-ms-client-name"] || $.operationId;
   #############################
   # Make connectionId and x-ms-api-version only global params
   #############################

--- a/sdk/swaggers/ms-services/released/aci.json
+++ b/sdk/swaggers/ms-services/released/aci.json
@@ -1567,6 +1567,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#list-subscriptions"
         },
         "operationId": "Subscriptions_List",
+        "x-ms-client-name": "ListSubscriptions",
         "parameters": [
           {
             "in": "path",
@@ -1611,6 +1612,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-a-list-of-container-groups-in-a-subscription"
         },
         "operationId": "ContainerGroups_List",
+        "x-ms-client-name": "ListContainerGroups",
         "parameters": [
           {
             "in": "path",
@@ -1655,6 +1657,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-cached-images"
         },
         "operationId": "Location_ListCachedImages",
+        "x-ms-client-name": "GetCachedImages",
         "parameters": [
           {
             "in": "path",
@@ -1702,6 +1705,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-capabilities"
         },
         "operationId": "Location_ListCapabilities",
+        "x-ms-client-name": "GetCapabilities",
         "parameters": [
           {
             "in": "path",
@@ -1864,6 +1868,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-current-usage"
         },
         "operationId": "Location_ListUsage",
+        "x-ms-client-name": "GetCurrentUsage",
         "parameters": [
           {
             "in": "path",
@@ -1908,6 +1913,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-a-list-of-container-groups-in-a-resource-group"
         },
         "operationId": "ContainerGroups_ListByResourceGroup",
+        "x-ms-client-name": "ListContainerGroupsByResourceGroup",
         "parameters": [
           {
             "in": "path",
@@ -1955,6 +1961,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#delete-a-container-group"
         },
         "operationId": "ContainerGroups_Delete",
+        "x-ms-client-name": "DeleteContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2005,6 +2012,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-properties-of-a-container-group"
         },
         "operationId": "ContainerGroups_Get",
+        "x-ms-client-name": "GetContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2050,6 +2058,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#update-a-container-group-location-or-tags"
         },
         "operationId": "ContainerGroups_Update",
+        "x-ms-client-name": "UpdateContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2103,6 +2112,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#create-or-update-a-container-group"
         },
         "operationId": "ContainerGroups_CreateOrUpdate",
+        "x-ms-client-name": "CreateOrUpdateContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2164,6 +2174,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-logs-from-a-container-instance"
         },
         "operationId": "ContainerLogs_List",
+        "x-ms-client-name": "GetContainerLogs",
         "parameters": [
           {
             "in": "path",
@@ -2226,6 +2237,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#restart-containers-in-a-container-group"
         },
         "operationId": "ContainerGroups_Restart",
+        "x-ms-client-name": "RestartContainers",
         "parameters": [
           {
             "in": "path",
@@ -2269,6 +2281,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#start-containers-in-a-container-group"
         },
         "operationId": "ContainerGroups_Start",
+        "x-ms-client-name": "StartContainers",
         "parameters": [
           {
             "in": "path",
@@ -2312,6 +2325,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#stop-containers-in-a-container-group"
         },
         "operationId": "ContainerGroups_Stop",
+        "x-ms-client-name": "StopContainers",
         "parameters": [
           {
             "in": "path",
@@ -2352,6 +2366,7 @@
           "url": "https://docs.microsoft.com/connectors/aci/#list-resource-groups"
         },
         "operationId": "ResourceGroups_List",
+        "x-ms-client-name": "ListResourceGroups",
         "parameters": [
           {
             "in": "path",


### PR DESCRIPTION
I can remove the changes to aci.json as well - just used to test.
Changes:
1. Use "x-ms-client-name" for "operationId" if it's present
2. Update helper description for "x-ms-dynamic" values that previously referenced helper methods by operationId

Currently, "x-ms-client-name" is only used for parameter naming by AutoRest: https://azure.github.io/autorest/extensions/#x-ms-client-name

<img width="956" alt="Screen Shot 2021-02-08 at 1 12 50 PM" src="https://user-images.githubusercontent.com/8888531/107282106-68309480-6a0f-11eb-8b23-2cef51235152.png">
