### PR TITLE
Helper script to create friendly names for swaggers

### DIFF
--- a/sdk/Scripts/CreateFriendlyMethodNames.js
+++ b/sdk/Scripts/CreateFriendlyMethodNames.js
@@ -74,6 +74,7 @@ async function run() {
                 console.log("=====================");
                 console.log(`Operation ID: \t\t${action.operationId}`);
                 console.log(`Visibility: \t\t${action["x-ms-visibility"]}`);
+                console.log(`Summary: \t\t${action.summary}`);
                 console.log(`Description: \t\t${action.description}`);
                 console.log(`URL: \t\t\t${action.externalDocs.url}`);
                 console.log(`x-ms-client-name: \t${action["x-ms-client-name"]}`);

--- a/sdk/Scripts/CreateFriendlyMethodNames.js
+++ b/sdk/Scripts/CreateFriendlyMethodNames.js
@@ -1,0 +1,103 @@
+// This script is a helper to quickly create friendly swagger names
+// Ignore trigger and deprecated API's
+//
+// First argument: File path to swagger
+// Second argument (optional): File path to output swagger. Will overwrite if none.
+//
+// example:
+// > node sdk/Scripts/CreateFriendlyMethodNames.js sdk/swaggers/ms-services/released/aci.json aci2.json
+
+const readline = require('readline');
+const util = require('util');
+const fs = require('fs');
+
+const JSON_SPACING = "  ";
+const myArgs = process.argv.slice(2);
+const swaggerFile = myArgs[0];
+const outputSwaggerFile = myArgs[1];
+const readFileAsync = util.promisify(fs.readFile);
+
+function askQuestion(query) {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    return new Promise(resolve => rl.question(query, answer => {
+        rl.close();
+        resolve(answer);
+    }))
+}
+
+async function getName() {
+    let ans = await askQuestion("Please enter a friendly name or press enter to skip...\n");
+    if (ans) {
+        let confirm = await askQuestion(`Confirm '${ans}'? (y/n)`);
+        if (confirm == "y") {
+            return ans;
+        } else {
+            console.log("Trying again...");
+            return await getName();
+        }
+    }
+}
+
+async function continueOrTerminate() {
+    const ans = await askQuestion("Continue? (y/n)");
+    if (ans != "y") {
+        console.log("Terminating program...");
+        process.exit();
+    }
+}
+
+async function run() {
+    try {
+        // Prompts to make sure the user knows what they're doing
+        if (outputSwaggerFile) {
+            console.log(`Reading swagger from: '${swaggerFile}'`)
+            console.log(`Writing swagger to: '${outputSwaggerFile}'`)
+            await continueOrTerminate();
+        } else {
+            console.log(`IMPORTANT: this script will overwrite the existing contents of ${swaggerFile}`);
+            await continueOrTerminate();
+        }
+        // Loop through API's and optionally rename operationId's
+        const changes = {};
+        const swaggerData = await readFileAsync(swaggerFile, 'utf8');
+        const swagger = JSON.parse(swaggerData);
+        for (let path in swagger.paths) {
+            for (let method in swagger.paths[path]) {
+                let action = swagger.paths[path][method];
+                if (action["x-ms-trigger"] || action.deprecated) {
+                    continue;
+                }
+                console.log("=====================");
+                console.log(`Operation ID: \t\t${action.operationId}`);
+                console.log(`Visibility: \t\t${action["x-ms-visibility"]}`);
+                console.log(`Description: \t\t${action.description}`);
+                console.log(`URL: \t\t\t${action.externalDocs.url}`);
+                console.log(`x-ms-client-name: \t${action["x-ms-client-name"]}`);
+                let newName = await getName();
+                if (newName) {
+                    changes[action.operationId] = newName;
+                    action["x-ms-client-name"] = newName;
+                }
+            }
+        }
+
+        // Confirm one last time with the user that everything looks good
+        console.log("\n\nMaking the following changes:")
+        for (let oldName in changes) {
+            console.log(`\t${oldName} => ${changes[oldName]}`);
+        }
+        await continueOrTerminate();
+
+        const output = outputSwaggerFile || swaggerFilel
+        fs.writeFileSync(output, JSON.stringify(swagger, null, JSON_SPACING));
+    } catch (err) {
+        console.error(err)
+    }
+}
+
+run();
+

--- a/sdk/Scripts/CreateFriendlyMethodNames.js
+++ b/sdk/Scripts/CreateFriendlyMethodNames.js
@@ -32,8 +32,8 @@ function askQuestion(query) {
 async function getName() {
     let ans = await askQuestion("Please enter a friendly name or press enter to skip...\n");
     if (ans) {
-        let confirm = await askQuestion(`Confirm '${ans}'? (y/n)`);
-        if (confirm == "y") {
+        let confirm = await askQuestion(`Confirm '${ans}'? ("y" or enter to accept)`);
+        if (confirm == "y" || confirm == "") {
             return ans;
         } else {
             console.log("Trying again...");
@@ -58,7 +58,7 @@ async function run() {
             console.log(`Writing swagger to: '${outputSwaggerFile}'`)
             await continueOrTerminate();
         } else {
-            console.log(`IMPORTANT: this script will overwrite the existing contents of ${swaggerFile}`);
+            console.warn(`IMPORTANT: this script will overwrite the existing contents of ${swaggerFile}`);
             await continueOrTerminate();
         }
         // Loop through API's and optionally rename operationId's

--- a/sdk/Scripts/CreateFriendlyMethodNames.js
+++ b/sdk/Scripts/CreateFriendlyMethodNames.js
@@ -87,7 +87,7 @@ async function run() {
         }
 
         // Confirm one last time with the user that everything looks good
-        console.log("\n\nMaking the following changes:")
+        console.warn("\nMaking the following changes:")
         for (let oldName in changes) {
             console.log(`\t${oldName} => ${changes[oldName]}`);
         }


### PR DESCRIPTION
Runs through a series of prompts to speed up manual process of giving API operationId's more friendly names to become methods

```
...
=====================
Operation ID:           Subscriptions_List
Visibility:             internal
Summary:                List subscriptions
Description:            Gets a list of all the subscriptions to which the principal has access.
URL:                    https://docs.microsoft.com/connectors/aci/#list-subscriptions
Current x-ms-client-name:       ListSubscriptions
Please enter a friendly name or press enter to skip...


Making the following changes:
        AsyncOperations_GetLocationResult => GetLocationResult
Continue? (y/n)y
```