### PR TITLE
Give friendly name to operations using a custom directive rename-operation-extended

### DIFF
--- a/sdk/ReleaseConfigs/ReleaseConfig_MicrosoftOnly_staged.json
+++ b/sdk/ReleaseConfigs/ReleaseConfig_MicrosoftOnly_staged.json
@@ -2,7 +2,13 @@
   {
 		"name": "azurequeues" ,
 		"friendlyName": "AzureQueues",
-		"version": "0.0.4-alpha",
+		"version": "0.0.5-alpha",
 		"autoRestConfigFile": ".\\sdk\\autorest\\customConfigs\\azurequeues.md"
+	},
+	{
+		"name": "aci" ,
+		"friendlyName": "AzureContainerInstance",
+		"version": "0.0.5-alpha",
+		"autoRestConfigFile": ".\\sdk\\autorest\\customConfigs\\aci.md"
 	}
 ]

--- a/sdk/autorest/customConfigs/aci.md
+++ b/sdk/autorest/customConfigs/aci.md
@@ -1,0 +1,58 @@
+# [ConnectorName] Custom Config
+
+> see https://aka.ms/autorest
+
+## Configuration
+
+```yaml
+# https://github.com/Azure/autorest/blob/master/Samples/openapi-v2/3h-try-require/readme.md
+require: ../readme.md
+
+# Add your own config below
+directive: 
+  - rename-operation-extended:
+      from: Subscriptions_List
+      to: ListSubscriptions
+  - rename-operation-extended:
+      from: ContainerGroups_List
+      to: ListContainerGroups
+  - rename-operation-extended:
+      from: Location_ListCachedImages
+      to: GetCachedImages
+  - rename-operation-extended:
+      from: Location_ListCapabilities
+      to: GetCapabilities
+  - rename-operation-extended:
+      from: Location_ListUsage
+      to: GetCurrentUsage
+  - rename-operation-extended:
+      from: ContainerGroups_ListByResourceGroup
+      to: ListContainerGroupsByResourceGroup
+  - rename-operation-extended:
+      from: ContainerGroups_Delete
+      to: DeleteContainerGroup
+  - rename-operation-extended:
+      from: ContainerGroups_Get
+      to: GetContainerGroup
+  - rename-operation-extended:
+      from: ContainerGroups_Update
+      to: UpdateContainerGroup
+  - rename-operation-extended:
+      from: ContainerGroups_CreateOrUpdate
+      to: CreateOrUpdateContainerGroup
+  - rename-operation-extended:
+      from: ContainerLogs_List
+      to: GetContainerLogs
+  - rename-operation-extended:
+      from: ContainerGroups_Restart
+      to: RestartContainers
+  - rename-operation-extended:
+      from: ContainerGroups_Start
+      to: StartContainers
+  - rename-operation-extended:
+      from: ContainerGroups_Stop
+      to: StopContainers
+  - rename-operation-extended:
+      from: ResourceGroups_List
+      to: ListResourceGroups
+```

--- a/sdk/autorest/readme.md
+++ b/sdk/autorest/readme.md
@@ -10,18 +10,11 @@ azure-arm: true
 
 ```yaml
 declare-directive:
-  # TODO: 
-  # - Migrate other directive using x-ms-client-name and completely remove the property
-  # - merge with existing `rename-operation` once we completely migrate off of x-ms-client-name
+  # rename operationId at any level
   rename-operation-extended: >-
     [{
       from: 'swagger-document',
-      where: `$.parameters[?(@["x-ms-dynamic-values"].operationId == ${JSON.stringify($.from)})]`,
-      transform: `$["x-ms-dynamic-values"].operationId = ${JSON.stringify($.to)}`
-    },
-    {
-      from: 'swagger-document',
-      where: `$.paths.*[?(@.operationId == ${JSON.stringify($.from)})]`,
+      where: `$..[?(@["operationId"] == ${JSON.stringify($.from)})]`,
       transform: `$.operationId = ${JSON.stringify($.to)}`
     }]
 directive:
@@ -97,7 +90,7 @@ directive:
             /* Use x-ms-client-name if it's there */
             let modifiedOperationId = action["x-ms-client-name"] || action.operationId;
             /* Change description */
-            dynamicInput.parameter.description = (dynamicInput.parameter.description || "") + `\nYou can get this value by calling '${modifiedOperationId}' and using the '${dynamicInput.parameterName}' value).`;
+            dynamicInput.parameter.description = (dynamicInput.parameter.description || "") + `\nYou can get this value by calling '${modifiedOperationId}' and using the '${dynamicInput.parameterName}' value.`;
           }
         }
       }

--- a/sdk/autorest/readme.md
+++ b/sdk/autorest/readme.md
@@ -17,24 +17,13 @@ declare-directive:
     [{
       from: 'swagger-document',
       where: `$.parameters[?(@["x-ms-dynamic-values"].operationId == ${JSON.stringify($.from)})]`,
-      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-values"]["value-path"] + "' value."`
+      transform: `$["x-ms-dynamic-values"].operationId = ${JSON.stringify($.to)}`
     },
     {
       from: 'swagger-document',
-      where: `$.parameters[?(@["x-ms-dynamic-schema"].operationId == ${JSON.stringify($.from)})]`,
-      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-schema"]["value-path"] + "' value."`
-    },
-    {
-      from: 'swagger-document',
-      where: `$.parameters[?(@["x-ms-dynamic-list"].operationId == ${JSON.stringify($.from)})]`,
-      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-list"]["ItemValuePath"] + "' value."`
-    },
-    {
-      from: 'swagger-document',
-      where: `$.parameters[?(@["x-ms-dynamic-values"].operationId == ${JSON.stringify($.from)})]`,
-      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-values"]["ItemValuePath"] + "' value."`
+      where: `$.paths.*[?(@.operationId == ${JSON.stringify($.from)})]`,
+      transform: `$.operationId = ${JSON.stringify($.to)}`
     }]
-
 directive:
   #############################
   # Remove underscore from operationId's
@@ -119,7 +108,7 @@ directive:
       if ($["x-ms-visibility"] === "internal") {
         return;
       }
-  # Use "x-ms-client-name" instead of "operationId" if it's there. 
+  # Use "x-ms-client-name" instead of "operationId" if it's there.
   # Note that references to "operationId" for dynamic values has been fixed above.
   - from: swagger-document
     where: $..[?(@.operationId)]

--- a/sdk/autorest/readme.md
+++ b/sdk/autorest/readme.md
@@ -90,6 +90,10 @@ directive:
           let dynamicInput = dynamicInputOperations[action.operationId];
           if (dynamicInput && dynamicInput.parameter) {
             action["x-ms-visibility"] = action["x-ms-visibility"] + "-dynamic";
+            /* Use x-ms-client-name if it's there */
+            let modifiedOperationId = action["x-ms-client-name"] || action.operationId;
+            /* Change description */
+            dynamicInput.parameter.description = (dynamicInput.parameter.description || "") + `\nYou can get this value by calling '${modifiedOperationId}' and using the '${dynamicInput.parameterName}' value).`;
           }
         }
       }

--- a/sdk/autorest/readme.md
+++ b/sdk/autorest/readme.md
@@ -18,6 +18,21 @@ declare-directive:
       from: 'swagger-document',
       where: `$.parameters[?(@["x-ms-dynamic-values"].operationId == ${JSON.stringify($.from)})]`,
       transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-values"]["value-path"] + "' value."`
+    },
+    {
+      from: 'swagger-document',
+      where: `$.parameters[?(@["x-ms-dynamic-schema"].operationId == ${JSON.stringify($.from)})]`,
+      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-schema"]["value-path"] + "' value."`
+    },
+    {
+      from: 'swagger-document',
+      where: `$.parameters[?(@["x-ms-dynamic-list"].operationId == ${JSON.stringify($.from)})]`,
+      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-list"]["ItemValuePath"] + "' value."`
+    },
+    {
+      from: 'swagger-document',
+      where: `$.parameters[?(@["x-ms-dynamic-values"].operationId == ${JSON.stringify($.from)})]`,
+      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-values"]["ItemValuePath"] + "' value."`
     }]
 
 directive:

--- a/sdk/autorest/readme.md
+++ b/sdk/autorest/readme.md
@@ -9,6 +9,17 @@ azure-arm: true
 ```
 
 ```yaml
+declare-directive:
+  # TODO: 
+  # - Migrate other directive using x-ms-client-name and completely remove the property
+  # - merge with existing `rename-operation` once we completely migrate off of x-ms-client-name
+  rename-operation-extended: >-
+    [{
+      from: 'swagger-document',
+      where: `$.parameters[?(@["x-ms-dynamic-values"].operationId == ${JSON.stringify($.from)})]`,
+      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $.name + "' value."`
+    }]
+
 directive:
   #############################
   # Remove underscore from operationId's
@@ -79,10 +90,6 @@ directive:
           let dynamicInput = dynamicInputOperations[action.operationId];
           if (dynamicInput && dynamicInput.parameter) {
             action["x-ms-visibility"] = action["x-ms-visibility"] + "-dynamic";
-            /* Use x-ms-client-name if it's there */
-            let modifiedOperationId = action["x-ms-client-name"] || action.operationId;
-            /* Change description */
-            dynamicInput.parameter.description = (dynamicInput.parameter.description || "") + `\nYou can get this value by calling '${modifiedOperationId}' and using the '${dynamicInput.parameterName}' value).`;
           }
         }
       }

--- a/sdk/autorest/readme.md
+++ b/sdk/autorest/readme.md
@@ -17,7 +17,7 @@ declare-directive:
     [{
       from: 'swagger-document',
       where: `$.parameters[?(@["x-ms-dynamic-values"].operationId == ${JSON.stringify($.from)})]`,
-      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $.name + "' value."`
+      transform: `$.description = ($.description || "") + \`\nYou can get this value by calling '${$.to}' and using the '\` + $["x-ms-dynamic-values"]["value-path"] + "' value."`
     }]
 
 directive:

--- a/sdk/swaggers/ms-services/released/aci.json
+++ b/sdk/swaggers/ms-services/released/aci.json
@@ -1567,7 +1567,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#list-subscriptions"
         },
         "operationId": "Subscriptions_List",
-        "x-ms-client-name": "ListSubscriptions",
         "parameters": [
           {
             "in": "path",
@@ -1612,7 +1611,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-a-list-of-container-groups-in-a-subscription"
         },
         "operationId": "ContainerGroups_List",
-        "x-ms-client-name": "ListContainerGroups",
         "parameters": [
           {
             "in": "path",
@@ -1657,7 +1655,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-cached-images"
         },
         "operationId": "Location_ListCachedImages",
-        "x-ms-client-name": "GetCachedImages",
         "parameters": [
           {
             "in": "path",
@@ -1705,7 +1702,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-capabilities"
         },
         "operationId": "Location_ListCapabilities",
-        "x-ms-client-name": "GetCapabilities",
         "parameters": [
           {
             "in": "path",
@@ -1868,7 +1864,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-current-usage"
         },
         "operationId": "Location_ListUsage",
-        "x-ms-client-name": "GetCurrentUsage",
         "parameters": [
           {
             "in": "path",
@@ -1913,7 +1908,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-a-list-of-container-groups-in-a-resource-group"
         },
         "operationId": "ContainerGroups_ListByResourceGroup",
-        "x-ms-client-name": "ListContainerGroupsByResourceGroup",
         "parameters": [
           {
             "in": "path",
@@ -1961,7 +1955,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#delete-a-container-group"
         },
         "operationId": "ContainerGroups_Delete",
-        "x-ms-client-name": "DeleteContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2012,7 +2005,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-properties-of-a-container-group"
         },
         "operationId": "ContainerGroups_Get",
-        "x-ms-client-name": "GetContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2058,7 +2050,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#update-a-container-group-location-or-tags"
         },
         "operationId": "ContainerGroups_Update",
-        "x-ms-client-name": "UpdateContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2112,7 +2103,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#create-or-update-a-container-group"
         },
         "operationId": "ContainerGroups_CreateOrUpdate",
-        "x-ms-client-name": "CreateOrUpdateContainerGroup",
         "parameters": [
           {
             "in": "path",
@@ -2174,7 +2164,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#get-logs-from-a-container-instance"
         },
         "operationId": "ContainerLogs_List",
-        "x-ms-client-name": "GetContainerLogs",
         "parameters": [
           {
             "in": "path",
@@ -2237,7 +2226,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#restart-containers-in-a-container-group"
         },
         "operationId": "ContainerGroups_Restart",
-        "x-ms-client-name": "RestartContainers",
         "parameters": [
           {
             "in": "path",
@@ -2281,7 +2269,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#start-containers-in-a-container-group"
         },
         "operationId": "ContainerGroups_Start",
-        "x-ms-client-name": "StartContainers",
         "parameters": [
           {
             "in": "path",
@@ -2325,7 +2312,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#stop-containers-in-a-container-group"
         },
         "operationId": "ContainerGroups_Stop",
-        "x-ms-client-name": "StopContainers",
         "parameters": [
           {
             "in": "path",
@@ -2366,7 +2352,6 @@
           "url": "https://docs.microsoft.com/connectors/aci/#list-resource-groups"
         },
         "operationId": "ResourceGroups_List",
-        "x-ms-client-name": "ListResourceGroups",
         "parameters": [
           {
             "in": "path",


### PR DESCRIPTION
I migrated one directive to a custom directive so that we can rely less on x-ms-client-name in the swagger file. This was more complicated than I thought and will take time until we migrate every directive on x-ms-client-name & fully verify. 

I verified this change by running diff on core-model-v1 files. 