### PR TITLE
feat: add page_crash issue template for portal failure auto-reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/page_crash.yml
+++ b/.github/ISSUE_TEMPLATE/page_crash.yml
@@ -145,12 +145,3 @@ body:
       description: Screenshots (drag to attach), suspected cause, etc.
     validations:
       required: false
-
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Confidentiality
-      description: We auto-fill tenant + subscription IDs and a sanitized URL (origin + path, no query string). Please confirm before submitting.
-      options:
-        - label: I confirm this report contains no secrets, tokens, passwords, or customer data beyond the tenant and subscription identifiers shown above.
-          required: true

--- a/.github/ISSUE_TEMPLATE/page_crash.yml
+++ b/.github/ISSUE_TEMPLATE/page_crash.yml
@@ -21,6 +21,7 @@ body:
     id: crash-type
     attributes:
       label: Type of failure
+      default: 0
       options:
         - Page crash / blank white screen
         - JavaScript exception / unhandled error
@@ -42,13 +43,13 @@ body:
     id: repro-steps
     attributes:
       label: What were you doing when it happened?
-      description: Steps you took just before the failure. If you can reproduce it, list the steps.
+      description: Steps you took just before the failure. If you can reproduce it, list the steps. Optional so an auto-reported crash can be submitted as-is — but reproduction steps from a real person are gold.
       placeholder: |
         1. Opened ...
         2. Clicked ...
         3. Saw ...
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: error-message
@@ -83,6 +84,24 @@ body:
       label: Correlation / request ID
       description: Used by the backend to trace the failure. Auto-filled when available.
       placeholder: e.g. x-ms-request-id, session id, trace id
+    validations:
+      required: false
+
+  - type: input
+    id: tenant-id
+    attributes:
+      label: Entra tenant ID
+      description: GUID of the signed-in tenant. Used for triage only — no tokens or secrets.
+      placeholder: 00000000-0000-0000-0000-000000000000
+    validations:
+      required: false
+
+  - type: input
+    id: subscription-id
+    attributes:
+      label: Azure subscription ID
+      description: GUID of the currently-selected subscription. Used for triage only.
+      placeholder: 00000000-0000-0000-0000-000000000000
     validations:
       required: false
 
@@ -123,6 +142,15 @@ body:
     id: additional
     attributes:
       label: Anything else
-      description: Screenshots (drag to attach), tenant info, suspected cause, etc.
+      description: Screenshots (drag to attach), suspected cause, etc.
     validations:
       required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confidentiality
+      description: We auto-fill tenant + subscription IDs and a sanitized URL (origin + path, no query string). Please confirm before submitting.
+      options:
+        - label: I confirm this report contains no secrets, tokens, passwords, or customer data beyond the tenant and subscription identifiers shown above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/page_crash.yml
+++ b/.github/ISSUE_TEMPLATE/page_crash.yml
@@ -1,0 +1,128 @@
+name: Page crash / browser failure
+description: Report a page crash, JavaScript exception, or browser-side failure. Designed to be auto-filled by a "Report a problem" button on the website.
+title: "[Page crash] "
+labels: ["bug", "page-crash"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! If you arrived here from a **Report a problem** button in the product, most fields below will already be filled in for you. Just add anything you remember about what you were doing and click **Submit**.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One-line summary
+      description: What broke, in a sentence.
+      placeholder: e.g. "Dashboard went blank after clicking 'Create namespace'"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: crash-type
+    attributes:
+      label: Type of failure
+      options:
+        - Page crash / blank white screen
+        - JavaScript exception / unhandled error
+        - Network / API failure (4xx, 5xx, timeout)
+        - UI froze / unresponsive
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL where it happened
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: What were you doing when it happened?
+      description: Steps you took just before the failure. If you can reproduce it, list the steps.
+      placeholder: |
+        1. Opened ...
+        2. Clicked ...
+        3. Saw ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-message
+    attributes:
+      label: Error message / stack trace
+      description: Auto-filled when launched from the product. Otherwise paste here.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: console-logs
+    attributes:
+      label: Console logs (last few entries)
+      description: Auto-filled when launched from the product. Truncated to fit in the URL.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: network-errors
+    attributes:
+      label: Failed network requests
+      description: Auto-filled when launched from the product.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: correlation-id
+    attributes:
+      label: Correlation / request ID
+      description: Used by the backend to trace the failure. Auto-filled when available.
+      placeholder: e.g. x-ms-request-id, session id, trace id
+    validations:
+      required: false
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version / build / commit SHA
+      description: Auto-filled by the product.
+    validations:
+      required: false
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser & version (User-Agent)
+      description: Auto-filled from navigator.userAgent.
+    validations:
+      required: false
+
+  - type: input
+    id: viewport
+    attributes:
+      label: Viewport size / device
+      placeholder: e.g. 1920x1080 desktop, 390x844 iPhone
+    validations:
+      required: false
+
+  - type: input
+    id: timestamp
+    attributes:
+      label: When did it happen?
+      description: ISO 8601 timestamp. Auto-filled.
+      placeholder: 2026-05-26T16:30:00.000Z
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else
+      description: Screenshots (drag to attach), tenant info, suspected cause, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/portal_bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal_bug.yml
@@ -1,0 +1,141 @@
+name: Portal bug report
+description: Report a bug in the Connector Namespaces portal (UX, navigation, forms, data display). Auto-filled from the in-product "Report a bug" button.
+title: "[Portal] "
+labels: ["bug", "portal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! If you arrived here from a **Report a bug** button in the portal, several fields below will already be filled in for you (page URL, app version, browser, tenant, subscription). Add a one-line summary and any extra detail you can, then submit.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One-line summary
+      description: What broke, in a sentence.
+      placeholder: e.g. "Connector gateway list shows duplicate rows after delete"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the portal
+      default: 6
+      options:
+        - Connector gateways
+        - MCP servers
+        - Connections
+        - Triggers
+        - Settings
+        - Authentication / sign-in
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      default: 1
+      options:
+        - Critical (data loss, blocked sign-in, broken for all users)
+        - High (blocked from completing a key task)
+        - Medium (workaround exists, but annoying)
+        - Low (cosmetic, minor)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you see that was wrong?
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: false
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      description: Auto-filled from the page you were on (query string and hash stripped).
+      placeholder: https://...
+    validations:
+      required: false
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version / build / commit SHA
+      description: Auto-filled by the portal.
+    validations:
+      required: false
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser & version (User-Agent)
+      description: Auto-filled from navigator.userAgent.
+    validations:
+      required: false
+
+  - type: input
+    id: viewport
+    attributes:
+      label: Viewport size & theme
+      placeholder: e.g. 1920x1080 @ dark
+    validations:
+      required: false
+
+  - type: input
+    id: tenant-id
+    attributes:
+      label: Entra tenant ID
+      description: GUID of the signed-in tenant. Used for triage only — no tokens or secrets.
+      placeholder: 00000000-0000-0000-0000-000000000000
+    validations:
+      required: false
+
+  - type: input
+    id: subscription-id
+    attributes:
+      label: Azure subscription ID
+      description: GUID of the currently-selected subscription. Used for triage only.
+      placeholder: 00000000-0000-0000-0000-000000000000
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else
+      description: Screenshots (drag to attach), suspected cause, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confidentiality
+      description: We auto-fill tenant + subscription IDs and a sanitized URL (origin + path, no query string). Please confirm before submitting.
+      options:
+        - label: I confirm this report contains no secrets, tokens, passwords, or customer data beyond the tenant and subscription identifiers shown above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/portal_bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal_bug.yml
@@ -130,12 +130,3 @@ body:
       description: Screenshots (drag to attach), suspected cause, etc.
     validations:
       required: false
-
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Confidentiality
-      description: We auto-fill tenant + subscription IDs and a sanitized URL (origin + path, no query string). Please confirm before submitting.
-      options:
-        - label: I confirm this report contains no secrets, tokens, passwords, or customer data beyond the tenant and subscription identifiers shown above.
-          required: true


### PR DESCRIPTION
## What

Adds a new `.github/ISSUE_TEMPLATE/page_crash.yml` template designed to be deep-linked from a **Report a problem** button in the portal (https://connectors.azure.com).

## Why

When a user hits a page crash, JS exception, or network failure, we want a one-click path that pre-fills:

- Error message + stack trace
- Last ~25 console log entries
- Failed network requests
- Browser User-Agent, viewport size
- App version / build / commit SHA
- Correlation / request ID for backend tracing
- Page URL + timestamp

so the issue lands in this repo with enough context to triage without a back-and-forth.

## How

The template uses GitHub issue forms. Any field with an `id` can be pre-filled via URL query parameters, e.g.:

```
https://github.com/Azure/Connectors/issues/new
  ?template=page_crash.yml
  &title=...
  &page-url=...
  &console-logs=...
  &browser=...
```

JS snippet for the portal is documented in the README of the corresponding portal repo (TBD).

## Server-side prerequisites done

- Created the `page-crash` label (so the template's `labels: [bug, page-crash]` works)

## Notes

- URL has an ~8000-char practical limit, so the portal's JS trims logs to ~25 lines / 2.5 KB before encoding.
- Existing `bug_report.yml` is unchanged and still available for manual generic bug reports.