### PR TITLE
chore: pre-public readiness bundle (CODEOWNERS, SUPPORT, dependabot, codeql, discussions)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owner for all paths
+# When this repo is public, all PRs will be routed to Azure-Connectors-Contributors for review.
+* @Azure/azure-connectors-contributors

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Security issue
     url: https://msrc.microsoft.com/create-report

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Discussions
+    url: https://github.com/Azure/Connectors/discussions
+    about: For questions, ideas, and community conversation, please use Discussions.
   - name: Security issue
     url: https://msrc.microsoft.com/create-report
     about: Please report security vulnerabilities to MSRC, NOT as a GitHub issue. See SECURITY.md.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot configuration.
+#
+# This file pre-wires dependency updates so they flow automatically as soon as
+# package manifests land in the repo. Update the package-ecosystem entries below
+# when the actual language stack is decided.
+#
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # GitHub Actions used in .github/workflows/*
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+      include: scope
+    labels:
+      - dependencies
+
+  # Uncomment when a package.json lands at the repo root.
+  # - package-ecosystem: npm
+  #   directory: /
+  #   schedule:
+  #     interval: weekly
+  #   open-pull-requests-limit: 10
+  #   commit-message:
+  #     prefix: chore(deps)
+  #     include: scope
+  #   labels:
+  #     - dependencies
+  #   groups:
+  #     all-minor-and-patch:
+  #       update-types: [minor, patch]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+# CodeQL analysis.
+#
+# Required by the main-branch ruleset's `code_scanning` rule. Auto-detects
+# supported languages; add `languages` explicitly under the matrix `language`
+# key once the stack is decided (e.g. javascript-typescript, python, csharp).
+#
+# Docs: https://docs.github.com/code-security/code-scanning
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 06:00 UTC, in case nothing else has triggered analysis.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          # Languages will be auto-detected. To add manually, list here, e.g.:
+          # - javascript-typescript
+          # - python
+          # - csharp
+          - actions
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,22 @@
+# Support
+
+This project is maintained by Microsoft. Here's where to get help.
+
+## How to file an issue
+
+| Type of issue | Where to go |
+|---|---|
+| 🐛 Bug in the **Connector Namespaces portal** | Use the in-product **Report a bug** button, or file a [Portal bug report](https://github.com/Azure/Connectors/issues/new?template=portal_bug.yml). |
+| 💥 **Page crash / JavaScript exception** | Auto-reported by the product when possible. Manual: [Page crash report](https://github.com/Azure/Connectors/issues/new?template=page_crash.yml). |
+| 🐞 Other bugs (SDKs, CLI, docs) | [Bug report](https://github.com/Azure/Connectors/issues/new?template=bug_report.yml). |
+| 💡 Feature request | [Feature request](https://github.com/Azure/Connectors/issues/new?template=feature_request.yml). |
+| 💬 Question or discussion | [GitHub Discussions](https://github.com/Azure/Connectors/discussions) or [Microsoft Q&A](https://learn.microsoft.com/answers/). |
+| 🔒 **Security vulnerability** | **Do not** open a public issue. Report to [MSRC](https://msrc.microsoft.com/create-report). See [SECURITY.md](SECURITY.md). |
+
+## Response times
+
+This is a community-supported open-source project. The Connector Namespaces team triages issues regularly but does not commit to a formal SLA on GitHub. For production support tied to your Azure subscription, please use [Azure Support](https://azure.microsoft.com/support/).
+
+## Microsoft Support Policy
+
+Support for this repository is limited to the resources listed above.


### PR DESCRIPTION
## What

Bundle of pre-public-release readiness improvements.

### Files added
- `.github/CODEOWNERS` -> routes every path to `@Azure/azure-connectors-contributors` for review.
- `SUPPORT.md` -> Microsoft OSS-standard support routing.
- `.github/dependabot.yml` -> pre-wires weekly updates for GitHub Actions; npm/etc. stubs commented out, ready to enable when the stack lands.
- `.github/workflows/codeql.yml` -> required for the main-branch ruleset's `code_scanning` rule to actually produce alerts; auto-detects languages.

### Files updated
- `.github/ISSUE_TEMPLATE/config.yml`
  - `blank_issues_enabled: false -> true` so community members can file freeform issues.
  - Added Discussions link as the first contact option (Discussions was just enabled on the repo).

## Done alongside (settings, not in this PR)

- Enabled Dependabot vulnerability alerts and security updates.
- Enabled Discussions and Forking.
- Tightened the `main` ruleset: dismiss stale reviews, code owner review (relies on this PR's CODEOWNERS), last-push approval, conversation resolution.
- Added repo topics: `azure`, `connectors`, `ai-agents`, `logic-apps`, `microsoft`, `connector-namespaces`.
- Set merge commit format to `PR_TITLE` / `PR_BODY` for both merge and squash.
- Created `portal` label (referenced by `portal_bug.yml`).

## Still TODO before going public (out of scope for this PR)

- Audit the 30 closed/merged historical PRs and their commit SHAs (still reachable via SHA, will become public).
- Complete OSPO self-attestation (issue #109).
- File public-release request via opensource.microsoft.com.
- Wire up the Microsoft CLA bot.