### PR TITLE
chore: align SECURITY.md and CODE_OF_CONDUCT.md with official Microsoft templates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,3 +7,4 @@ Resources:
 - [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
 - [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 - Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- Employees can reach out at [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,4 @@ For security reporting information, locations, contact information, and policies
 please review the latest guidance for Microsoft repositories at
 [https://aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
 
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+<!-- END MICROSOFT SECURITY.MD V1.0.0 BLOCK -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,4 @@ For security reporting information, locations, contact information, and policies
 please review the latest guidance for Microsoft repositories at
 [https://aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
 
-<!-- END MICROSOFT SECURITY.MD V1.0.0 BLOCK -->
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,33 +1,14 @@
-# Security Policy
+<!-- BEGIN MICROSOFT SECURITY.MD V1.0.0 BLOCK -->
 
-## Reporting Security Issues
+## Security
+
+Microsoft takes the security of our software products and services seriously, which
+includes all source code repositories in our GitHub organizations.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
+For security reporting information, locations, contact information, and policies,
+please review the latest guidance for Microsoft repositories at
+[https://aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com). If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
-
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
-
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
-
-- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-- Full paths of source file(s) related to the manifestation of the issue
-- The location of the affected source code (tag/branch/commit or direct URL)
-- Any special configuration required to reproduce the issue
-- Step-by-step instructions to reproduce the issue
-- Proof-of-concept or exploit code (if possible)
-- Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
-
-## Preferred Languages
-
-We prefer all communications to be in English.
-
-## Policy
-
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+<!-- END MICROSOFT SECURITY.MD BLOCK -->


### PR DESCRIPTION
## What

Aligns `SECURITY.md` and `CODE_OF_CONDUCT.md` with the **current** official Microsoft templates at https://github.com/microsoft/repo-templates/tree/main/shared.

### SECURITY.md
Replaces the deprecated long-form template (PGP key, inline MSRC details, etc.) with the **short pointer version** that includes the `<!-- BEGIN/END MICROSOFT SECURITY.MD V1.0.0 BLOCK -->` markers. Repolinter checks for these markers literally during OSPO release review.

### CODE_OF_CONDUCT.md
Adds the 4th Resources bullet linking to the **employee-only** `aka.ms/opensource/moderation-support` page so this file matches the official template exactly.

## Why

Pre-public-release readiness. The eng.ms OSPO releasing FAQ requires both files to use the official templates; mismatches typically surface as automated findings during the release review.

## Source of truth

- https://raw.githubusercontent.com/microsoft/repo-templates/main/shared/SECURITY.md
- https://raw.githubusercontent.com/microsoft/repo-templates/main/shared/CODE_OF_CONDUCT.md