### PR TITLE
fix(templates): remove invalid default on required dropdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/page_crash.yml
+++ b/.github/ISSUE_TEMPLATE/page_crash.yml
@@ -29,7 +29,7 @@ body:
         - UI froze / unresponsive
         - Other
     validations:
-      required: true
+      required: false
 
   - type: input
     id: page-url

--- a/.github/ISSUE_TEMPLATE/portal_bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal_bug.yml
@@ -31,7 +31,7 @@ body:
         - Authentication / sign-in
         - Other / not sure
     validations:
-      required: true
+      required: false
 
   - type: dropdown
     id: severity
@@ -44,7 +44,7 @@ body:
         - Medium (workaround exists, but annoying)
         - Low (cosmetic, minor)
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: what-happened


### PR DESCRIPTION
## Problem
GitHub Issue Forms rejects a `default` on **required** dropdown fields with the validation error:
> `default` cannot be used with required fields.

This broke two issue templates:
- `.github/ISSUE_TEMPLATE/page_crash.yml` — `crash-type` dropdown (`default: 0` + `required: true`)
- `.github/ISSUE_TEMPLATE/portal_bug.yml` — `area` (`default: 6`) and `severity` (`default: 1`) dropdowns, both `required: true`

## Fix
Set the affected dropdowns to `required: false`, preserving the pre-filled `default` selections. These are auto-report forms designed for as-is submission, so keeping the defaults (rather than removing them) maintains the intended auto-fill UX.

## Validation
Both templates now pass `check-jsonschema --builtin-schema vendor.github-issue-forms`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>