### PR TITLE
Fix connector-namespace installers to preserve wheel filename for az extension add

### DIFF
--- a/public-preview/connector-namespace-cli/install.ps1
+++ b/public-preview/connector-namespace-cli/install.ps1
@@ -59,17 +59,37 @@ if ($Version) {
 Write-Host "  Wheel: $wheelUrl"
 Write-Host ""
 
-# Download the wheel to a temp file, then install from the local file.
+# Download the wheel to a temp dir, then install from the local file.
 # (aka.ms is a redirect, so download first rather than pass the URL to az.)
-$wheelFile = Join-Path ([System.IO.Path]::GetTempPath()) "$PkgName.whl"
+# The file name must keep the real wheel name (e.g. connector_namespace-1.0.0b9-py3-none-any.whl)
+# because 'az extension add' parses the extension name/version from it.
+$tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("connector-namespace-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmpDir | Out-Null
 try {
-    Invoke-WebRequest -Uri $wheelUrl -OutFile $wheelFile -UseBasicParsing
+    $downloadPath = Join-Path $tmpDir 'download.bin'
+    $resp = Invoke-WebRequest -Uri $wheelUrl -OutFile $downloadPath -UseBasicParsing -PassThru
+
+    # Prefer the server-provided file name (Content-Disposition); the resolved
+    # redirect URL is an opaque blob id, so it can't be parsed for the name.
+    $wheelName = $null
+    $cd = $resp.Headers['Content-Disposition']
+    if ($cd) {
+        if ($cd -is [array]) { $cd = $cd[0] }
+        if ($cd -match 'filename\*?=(?:UTF-8'''')?"?([^";]+)"?') { $wheelName = $matches[1].Trim() }
+    }
+    if (-not $wheelName) {
+        if ($Version) { $wheelName = "${PkgName}-${Version}-py3-none-any.whl" } else { $wheelName = "${PkgName}.whl" }
+    }
+
+    $wheelFile = Join-Path $tmpDir $wheelName
+    Move-Item -Path $downloadPath -Destination $wheelFile -Force
 
     # --upgrade so re-running this script updates an existing install.
     # --yes accepts the "extension is in preview" prompt automatically.
     az extension add --upgrade --yes --source $wheelFile
+    if ($LASTEXITCODE -ne 0) { throw "az extension add failed (exit code $LASTEXITCODE)." }
 } finally {
-    Remove-Item -Path $wheelFile -ErrorAction SilentlyContinue
+    Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 Write-Host ""

--- a/public-preview/connector-namespace-cli/install.sh
+++ b/public-preview/connector-namespace-cli/install.sh
@@ -62,12 +62,29 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
-# Download the wheel to a temp file, then install from the local file.
+# Download the wheel to a temp dir, then install from the local file.
 # (aka.ms is a redirect, so download first rather than pass the URL to az.)
+# The file name must keep the real wheel name (e.g. connector_namespace-1.0.0b9-py3-none-any.whl)
+# because 'az extension add' parses the extension name/version from it.
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
-WHEEL_FILE="$TMP_DIR/${PKG_NAME}.whl"
-curl -fsSL "$WHEEL_URL" -o "$WHEEL_FILE"
+HEADERS_FILE="$TMP_DIR/headers.txt"
+DOWNLOAD_FILE="$TMP_DIR/download.bin"
+curl -fsSL -D "$HEADERS_FILE" "$WHEEL_URL" -o "$DOWNLOAD_FILE"
+
+# Prefer the server-provided file name (Content-Disposition); the resolved
+# redirect URL is an opaque blob id, so it can't be parsed for the name.
+# tail picks the final redirect hop; cut/tr strip the prefix and any quotes.
+WHEEL_NAME="$(grep -io 'filename=[^;[:space:]]*' "$HEADERS_FILE" | tail -n1 | cut -d= -f2- | tr -d '"'\''\r')"
+if [ -z "$WHEEL_NAME" ]; then
+  if [ -n "$VERSION" ]; then
+    WHEEL_NAME="${PKG_NAME}-${VERSION}-py3-none-any.whl"
+  else
+    WHEEL_NAME="${PKG_NAME}.whl"
+  fi
+fi
+WHEEL_FILE="$TMP_DIR/$WHEEL_NAME"
+mv "$DOWNLOAD_FILE" "$WHEEL_FILE"
 
 # --upgrade so re-running this script updates an existing install.
 # --yes accepts the "extension is in preview" prompt automatically.


### PR DESCRIPTION
## What

Fixes the `connector-namespace` install scripts, which failed at the final step with:

```
Unable to determine extension name from .../connector_namespace.whl. Is the file name correct?
```

## Root cause

`az extension add --source <file>` parses the extension **name and version from the wheel file name** (PEP 427, e.g. `connector_namespace-1.0.0b9-py3-none-any.whl`). Both scripts downloaded the wheel to a fixed name `connector_namespace.whl`, so `az` could not parse it.

The `https://aka.ms/connector-namespace.whl` redirect resolves to an opaque release-asset blob id, so the final URL leaf can't be used to recover the name either.

## Fix

- Derive the real wheel file name from the **`Content-Disposition`** response header (reliable across the aka.ms redirect), falling back to a constructed name (`<pkg>-<version>-py3-none-any.whl` when pinned, else `<pkg>.whl`).
- Download into a temp dir under the correct name, then install from the local file.
- **install.ps1:** guard the success message on `$LASTEXITCODE`. Previously `az`'s nonzero exit did not throw, so a failed install still printed a misleading `✓ Installed`.

## Verification

Tested end-to-end locally with Azure CLI 2.84.0:

- `install.ps1` (default / aka.ms) → extension installs, `az connector-namespace --help` works.
- `install.sh` (default / aka.ms, via bash) → extension installs and is confirmed via `az extension show`.
- `install.ps1` parses (PowerShell Parser); `install.sh` passes `bash -n`.
