### PR TITLE
Use aka.ms install links and Bash/PowerShell doc sections

### DIFF
--- a/public-preview/connector-namespace-cli/README.md
+++ b/public-preview/connector-namespace-cli/README.md
@@ -14,41 +14,40 @@ Manage **`Microsoft.Web/connectorGateways`** (Connector Namespaces) and their ch
 
 ## Installation
 
-### Linux / macOS
+### Bash
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh | sh
+curl -fsSL https://aka.ms/connector-namespace-cli-install | sh
 ```
 
 Pin a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh \
-  | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
+curl -fsSL https://aka.ms/connector-namespace-cli-install | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
 ```
 
-### Windows (PowerShell)
+### PowerShell
 
 ```powershell
-irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1 | iex
+irm https://aka.ms/connector-namespace-cli-install-ps | iex
 ```
 
 Pin a specific version:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1))) -Version 1.0.0b9
+& ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Version 1.0.0b9
 ```
 
 ### Uninstall
 
 ```bash
-# Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh | sh -s -- --uninstall
+# Bash
+curl -fsSL https://aka.ms/connector-namespace-cli-install | sh -s -- --uninstall
 ```
 
 ```powershell
-# Windows
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1))) -Uninstall
+# PowerShell
+& ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Uninstall
 ```
 
 ### Verify the install

--- a/public-preview/connector-namespace-cli/README.md
+++ b/public-preview/connector-namespace-cli/README.md
@@ -20,22 +20,10 @@ Manage **`Microsoft.Web/connectorGateways`** (Connector Namespaces) and their ch
 curl -fsSL https://aka.ms/connector-namespace-cli-install | sh
 ```
 
-Pin a specific version:
-
-```bash
-curl -fsSL https://aka.ms/connector-namespace-cli-install | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
-```
-
 ### PowerShell
 
 ```powershell
 irm https://aka.ms/connector-namespace-cli-install-ps | iex
-```
-
-Pin a specific version:
-
-```powershell
-& ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Version 1.0.0b9
 ```
 
 ### Uninstall

--- a/public-preview/connector-namespace-cli/complete-reference.md
+++ b/public-preview/connector-namespace-cli/complete-reference.md
@@ -32,16 +32,16 @@ Reference documentation for the `connector-namespace` Azure CLI extension. Cover
 
 ## Installation
 
-### Linux / macOS
+### Bash
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh | sh
+curl -fsSL https://aka.ms/connector-namespace-cli-install | sh
 ```
 
-### Windows (PowerShell)
+### PowerShell
 
 ```powershell
-irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1 | iex
+irm https://aka.ms/connector-namespace-cli-install-ps | iex
 ```
 
 ### Version pinning
@@ -49,14 +49,13 @@ irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/conne
 By default the installer scripts install whatever the [`https://aka.ms/connector-namespace.whl`](https://aka.ms/connector-namespace.whl) redirect currently points at (the latest published wheel). To install a different version explicitly:
 
 ```bash
-# Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh \
-  | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
+# Bash
+curl -fsSL https://aka.ms/connector-namespace-cli-install | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
 ```
 
 ```powershell
-# Windows
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1))) -Version 1.0.0b9
+# PowerShell
+& ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Version 1.0.0b9
 ```
 
 ### Direct install (no scripts)
@@ -70,11 +69,11 @@ az extension add --upgrade --yes --source \
 ### Uninstall
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh | sh -s -- --uninstall
+curl -fsSL https://aka.ms/connector-namespace-cli-install | sh -s -- --uninstall
 ```
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1))) -Uninstall
+& ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Uninstall
 ```
 
 ### Verify

--- a/public-preview/connector-namespace-cli/complete-reference.md
+++ b/public-preview/connector-namespace-cli/complete-reference.md
@@ -44,20 +44,6 @@ curl -fsSL https://aka.ms/connector-namespace-cli-install | sh
 irm https://aka.ms/connector-namespace-cli-install-ps | iex
 ```
 
-### Version pinning
-
-By default the installer scripts install whatever the [`https://aka.ms/connector-namespace.whl`](https://aka.ms/connector-namespace.whl) redirect currently points at (the latest published wheel). To install a different version explicitly:
-
-```bash
-# Bash
-curl -fsSL https://aka.ms/connector-namespace-cli-install | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
-```
-
-```powershell
-# PowerShell
-& ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Version 1.0.0b9
-```
-
 ### Direct install (no scripts)
 
 ```bash

--- a/public-preview/connector-namespace-cli/install.ps1
+++ b/public-preview/connector-namespace-cli/install.ps1
@@ -2,13 +2,13 @@
 #
 # Usage:
 #   # Default: install the latest published wheel (https://aka.ms/connector-namespace.whl)
-#   irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1 | iex
+#   irm https://aka.ms/connector-namespace-cli-install-ps | iex
 #
 #   # Pin a different version:
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1))) -Version 1.0.0b9
+#   & ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Version 1.0.0b9
 #
 #   # Uninstall:
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.ps1))) -Uninstall
+#   & ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Uninstall
 
 [CmdletBinding()]
 param(

--- a/public-preview/connector-namespace-cli/install.sh
+++ b/public-preview/connector-namespace-cli/install.sh
@@ -3,14 +3,14 @@
 #
 # Usage:
 #   # Default: install the latest published wheel (https://aka.ms/connector-namespace.whl)
-#   curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh | sh
+#   curl -fsSL https://aka.ms/connector-namespace-cli-install | sh
 #
 #   # Pin a different version:
-#   curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh \
+#   curl -fsSL https://aka.ms/connector-namespace-cli-install \
 #     | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
 #
 #   # Uninstall:
-#   curl -fsSL https://raw.githubusercontent.com/Azure/Connectors/main/public-preview/connector-namespace-cli/install.sh \
+#   curl -fsSL https://aka.ms/connector-namespace-cli-install \
 #     | sh -s -- --uninstall
 
 set -eu


### PR DESCRIPTION
## What

Updates the CLI install documentation to use the official **aka.ms** short links, reorganizes the install instructions by **shell** instead of **OS**, and removes the version-pinning install commands.

### Install links
| Shell | Link |
|-------|------|
| Bash | `https://aka.ms/connector-namespace-cli-install` |
| PowerShell | `https://aka.ms/connector-namespace-cli-install-ps` |

### Section headings
- `Linux / macOS` → **Bash**
- `Windows (PowerShell)` → **PowerShell**

### Removed
- The "Pin a specific version" / "Version pinning" install command blocks from the docs.

## Files changed
- `public-preview/connector-namespace-cli/README.md` — install and uninstall commands now use the aka.ms links; sections renamed to Bash / PowerShell; version-pinning block removed.
- `public-preview/connector-namespace-cli/complete-reference.md` — same updates; "Version pinning" section removed.
- `public-preview/connector-namespace-cli/install.sh` / `install.ps1` — usage-comment headers updated to the aka.ms links.

No behavioral change to the installer logic itself (scripts still support version pinning via env var / `-Version`; it's just no longer documented in the install snippets).
