### PR TITLE
docs(connector-namespace-cli): bump install references to v1.0.0b33

### DIFF
--- a/public-preview/connector-namespace-cli/README.md
+++ b/public-preview/connector-namespace-cli/README.md
@@ -51,10 +51,10 @@ If you don't want to run a remote script, install the wheel directly from the Gi
 
 ```bash
 az extension add --upgrade --yes --source \
-    https://github.com/Azure/Connectors/releases/download/v1.0.0b9/connector_namespace-1.0.0b9-py3-none-any.whl
+    https://github.com/Azure/Connectors/releases/download/v1.0.0b33/connector_namespace-1.0.0b33-py3-none-any.whl
 ```
 
-For other versions, swap `v1.0.0b9` / `1.0.0b9` for the version you want — every release tag publishes a matching `connector_namespace-<VERSION>-py3-none-any.whl` asset.
+For other versions, swap `v1.0.0b33` / `1.0.0b33` for the version you want — every release tag publishes a matching `connector_namespace-<VERSION>-py3-none-any.whl` asset.
 
 ---
 

--- a/public-preview/connector-namespace-cli/complete-reference.md
+++ b/public-preview/connector-namespace-cli/complete-reference.md
@@ -2,7 +2,7 @@
 
 Reference documentation for the `connector-namespace` Azure CLI extension. Covers installation, every command group, authentication, argument shapes, and every error message we know about. Each section is independent — jump to whichever topic you need.
 
-> Verified against `connector-namespace 1.0.0b9`. Every snippet was executed before being pasted.
+> Verified against `connector-namespace 1.0.0b33`. Every snippet was executed before being pasted.
 
 ## Contents
 
@@ -49,7 +49,7 @@ irm https://aka.ms/connector-namespace-cli-install-ps | iex
 ```bash
 # Direct from the GitHub Release asset
 az extension add --upgrade --yes --source \
-    https://github.com/Azure/Connectors/releases/download/v1.0.0b9/connector_namespace-1.0.0b9-py3-none-any.whl
+    https://github.com/Azure/Connectors/releases/download/v1.0.0b33/connector_namespace-1.0.0b33-py3-none-any.whl
 ```
 
 ### Uninstall
@@ -68,7 +68,7 @@ curl -fsSL https://aka.ms/connector-namespace-cli-install | sh -s -- --uninstall
 az extension show --name connector-namespace --query "{name:name, version:version, preview:preview}" -o table
 # Name                 Version   Preview
 # -------------------  --------  ---------
-# connector-namespace  1.0.0b9   True
+# connector-namespace  1.0.0b33   True
 
 az connector-namespace --help
 ```

--- a/public-preview/connector-namespace-cli/install.ps1
+++ b/public-preview/connector-namespace-cli/install.ps1
@@ -5,7 +5,7 @@
 #   irm https://aka.ms/connector-namespace-cli-install-ps | iex
 #
 #   # Pin a different version:
-#   & ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Version 1.0.0b9
+#   & ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Version 1.0.0b33
 #
 #   # Uninstall:
 #   & ([scriptblock]::Create((irm https://aka.ms/connector-namespace-cli-install-ps))) -Uninstall
@@ -61,7 +61,7 @@ Write-Host ""
 
 # Download the wheel to a temp dir, then install from the local file.
 # (aka.ms is a redirect, so download first rather than pass the URL to az.)
-# The file name must keep the real wheel name (e.g. connector_namespace-1.0.0b9-py3-none-any.whl)
+# The file name must keep the real wheel name (e.g. connector_namespace-1.0.0b33-py3-none-any.whl)
 # because 'az extension add' parses the extension name/version from it.
 $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("connector-namespace-" + [System.Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tmpDir | Out-Null

--- a/public-preview/connector-namespace-cli/install.sh
+++ b/public-preview/connector-namespace-cli/install.sh
@@ -7,7 +7,7 @@
 #
 #   # Pin a different version:
 #   curl -fsSL https://aka.ms/connector-namespace-cli-install \
-#     | CONNECTOR_NAMESPACE_VERSION=1.0.0b9 sh
+#     | CONNECTOR_NAMESPACE_VERSION=1.0.0b33 sh
 #
 #   # Uninstall:
 #   curl -fsSL https://aka.ms/connector-namespace-cli-install \
@@ -64,7 +64,7 @@ fi
 
 # Download the wheel to a temp dir, then install from the local file.
 # (aka.ms is a redirect, so download first rather than pass the URL to az.)
-# The file name must keep the real wheel name (e.g. connector_namespace-1.0.0b9-py3-none-any.whl)
+# The file name must keep the real wheel name (e.g. connector_namespace-1.0.0b33-py3-none-any.whl)
 # because 'az extension add' parses the extension name/version from it.
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT


### PR DESCRIPTION
## What

Bumps the connector-namespace CLI install references from **1.0.0b9** → **1.0.0b33** for the new preview release, across `public-preview/connector-namespace-cli/`:

| File | Change |
|---|---|
| `README.md` | direct-install URL + "swap version" example → b33 |
| `complete-reference.md` | install URL, `az extension show` sample output, and the "Verified against" header → b33 |
| `install.ps1` | `-Version 1.0.0b33` usage example + wheel-name comment |
| `install.sh` | `CONNECTOR_NAMESPACE_VERSION=1.0.0b33` usage example + wheel-name comment |

## Why / how the "latest" install actually resolves

`install.ps1` / `install.sh` (served via `aka.ms/connector-namespace-cli-install` / `-install-ps`) **default to the `https://aka.ms/connector-namespace.whl` redirect** for the latest wheel; they only build a pinned GitHub-release URL when a version is passed explicitly. So:

- ✅ The functional **"default install = b33"** step is **repointing `aka.ms/connector-namespace.whl` → the v1.0.0b33 release asset** (done outside this repo, in the aka.ms portal). No script logic changes here.
- This PR only refreshes the **pinned URLs and version examples** so copy-paste installs and docs reference the current release.

Companion: GitHub Release **`v1.0.0b33`** (currently a draft prerelease) carries the matching `connector_namespace-1.0.0b33-py3-none-any.whl`.

## Follow-up (out of scope here)

`complete-reference.md`'s command body was authored against b9. A separate content pass is recommended to add b33's new commands (`connection authenticate`, `connector list-operations`, `list-locations`, `connection create --authenticate`) and to fix the breaking **`trigger --trigger-config-name` → `-n`** rename.