### PR TITLE
Pin CodeQL workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,15 +42,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Pins the GitHub Actions used by the CodeQL workflow to immutable 40-character commit SHAs while preserving the intended versions in comments.

| Action | Version | Commit SHA |
| --- | --- | --- |
| actions/checkout | v7 | 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 |
| github/codeql-action/init | v4 | 8aad20d150bbac5944a9f9d289da16a4b0d87c1e |
| github/codeql-action/analyze | v4 | 8aad20d150bbac5944a9f9d289da16a4b0d87c1e |

## Validation

- Verified the updated workflow content has no uses references whose ref is not a 40-character SHA.
- Scope is limited to .github/workflows/codeql.yml.

## Audit context

Part of the Azure/Connectors repository security baseline action queue: workflow action SHA pinning.