### PR TITLE
Add source archive release workflow and guide

### DIFF
--- a/.github/workflows/release-connector-namespace.yml
+++ b/.github/workflows/release-connector-namespace.yml
@@ -1,0 +1,239 @@
+name: Release connector namespace CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version without leading v, for example 1.0.0b34"
+        required: true
+        type: string
+      target_ref:
+        description: "Azure/Connectors ref or commit for the release tag"
+        required: true
+        default: "main"
+        type: string
+      wheel_url:
+        description: "HTTPS URL for connector_namespace-<version>-py3-none-any.whl from the approved build"
+        required: true
+        type: string
+      wheel_sha256:
+        description: "Expected SHA-256 of the wheel asset"
+        required: true
+        type: string
+      notes_start_tag:
+        description: "Previous release tag for generated notes, for example v1.0.0b33"
+        required: false
+        type: string
+      prerelease:
+        description: "Mark the GitHub Release as a prerelease"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-connector-namespace-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish connector namespace CLI release
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 30
+
+    steps:
+      - name: Validate release inputs
+        id: inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET_REF: ${{ inputs.target_ref }}
+          WHEEL_URL: ${{ inputs.wheel_url }}
+          WHEEL_SHA256: ${{ inputs.wheel_sha256 }}
+          NOTES_START_TAG: ${{ inputs.notes_start_tag }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
+            echo "version must look like 1.0.0 or 1.0.0b34 and must not include a leading v" >&2
+            exit 1
+          fi
+
+          if [[ ! "$WHEEL_URL" =~ ^https:// ]]; then
+            echo "wheel_url must be an HTTPS URL" >&2
+            exit 1
+          fi
+
+          if [[ ! "$WHEEL_SHA256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+            echo "wheel_sha256 must be a 64-character hex SHA-256" >&2
+            exit 1
+          fi
+
+          tag="v${VERSION}"
+          wheel_name="connector_namespace-${VERSION}-py3-none-any.whl"
+
+          if [[ -n "$NOTES_START_TAG" && ! "$NOTES_START_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
+            echo "notes_start_tag must look like v1.0.0 or v1.0.0b33" >&2
+            exit 1
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "wheel_name=$wheel_name"
+            echo "sha256_lower=${WHEEL_SHA256,,}"
+            echo "prerelease_flag=$([[ "$PRERELEASE" == "true" ]] && echo --prerelease || true)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ensure release tag does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists. Refusing to replace an immutable release." >&2
+            exit 1
+          fi
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Refusing to attach a new release to an existing protected tag." >&2
+            exit 1
+          fi
+
+      - name: Download and validate wheel
+        env:
+          VERSION: ${{ inputs.version }}
+          WHEEL_URL: ${{ inputs.wheel_url }}
+          EXPECTED_SHA256: ${{ steps.inputs.outputs.sha256_lower }}
+          WHEEL_NAME: ${{ steps.inputs.outputs.wheel_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          curl --fail --location --retry 3 --retry-all-errors --proto '=https' --tlsv1.2 \
+            --output "dist/${WHEEL_NAME}" \
+            "$WHEEL_URL"
+
+          actual_sha256="$(sha256sum "dist/${WHEEL_NAME}" | awk '{print tolower($1)}')"
+          if [[ "$actual_sha256" != "$EXPECTED_SHA256" ]]; then
+            echo "Wheel SHA-256 mismatch. Expected $EXPECTED_SHA256, got $actual_sha256" >&2
+            exit 1
+          fi
+
+          printf '%s  %s\n' "$actual_sha256" "$WHEEL_NAME" > "dist/${WHEEL_NAME}.sha256"
+
+          python - <<'PY'
+          import email.parser
+          import os
+          import pathlib
+          import sys
+          import zipfile
+
+          version = os.environ["VERSION"]
+          wheel_path = pathlib.Path("dist") / os.environ["WHEEL_NAME"]
+
+          with zipfile.ZipFile(wheel_path) as wheel:
+              metadata_names = [name for name in wheel.namelist() if name.endswith(".dist-info/METADATA")]
+              if len(metadata_names) != 1:
+                  raise SystemExit(f"Expected exactly one METADATA file, found {len(metadata_names)}")
+
+              metadata = email.parser.Parser().parsestr(wheel.read(metadata_names[0]).decode("utf-8"))
+
+          if metadata.get("Name") != "connector-namespace":
+              raise SystemExit(f"Unexpected package name: {metadata.get('Name')}")
+
+          if metadata.get("Version") != version:
+              raise SystemExit(f"Unexpected package version: {metadata.get('Version')} != {version}")
+          PY
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+          TARGET_REF: ${{ inputs.target_ref }}
+          NOTES_START_TAG: ${{ inputs.notes_start_tag }}
+          WHEEL_NAME: ${{ steps.inputs.outputs.wheel_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          request_file="$(mktemp)"
+          if [[ -n "$NOTES_START_TAG" ]]; then
+            jq -n --arg tag "$TAG" --arg target "$TARGET_REF" --arg previous "$NOTES_START_TAG" \
+              '{tag_name:$tag,target_commitish:$target,previous_tag_name:$previous}' > "$request_file"
+          else
+            jq -n --arg tag "$TAG" --arg target "$TARGET_REF" \
+              '{tag_name:$tag,target_commitish:$target}' > "$request_file"
+          fi
+
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            --input "$request_file" \
+            --jq '.body' > release-notes.generated.md
+
+          {
+            echo "Release artifact: ${WHEEL_NAME}"
+            echo
+            echo "SHA-256:"
+            echo
+            echo '```text'
+            cat "dist/${WHEEL_NAME}.sha256"
+            echo '```'
+            echo
+            cat release-notes.generated.md
+          } > release-notes.md
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+          TARGET_REF: ${{ inputs.target_ref }}
+          WHEEL_NAME: ${{ steps.inputs.outputs.wheel_name }}
+          PRERELEASE_FLAG: ${{ steps.inputs.outputs.prerelease_flag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh release create "$TAG" \
+            "dist/${WHEEL_NAME}" \
+            "dist/${WHEEL_NAME}.sha256" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$TARGET_REF" \
+            --title "${TAG} (preview)" \
+            --latest=false \
+            --fail-on-no-commits \
+            --notes-file release-notes.md \
+            $PRERELEASE_FLAG
+
+      - name: Read back release protections
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
+          echo "$release_json" | jq '{tag_name, draft, prerelease, immutable, target_commitish, assets: [.assets[].name]}'
+
+          immutable="$(echo "$release_json" | jq -r '.immutable')"
+          draft="$(echo "$release_json" | jq -r '.draft')"
+
+          if [[ "$draft" != "false" ]]; then
+            echo "Published release unexpectedly reports draft=$draft" >&2
+            exit 1
+          fi
+
+          if [[ "$immutable" != "true" ]]; then
+            echo "Published release did not report immutable=true" >&2
+            exit 1
+          fi
+
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" \
+            --jq '{ref, object}'

--- a/.github/workflows/release-connector-namespace.yml
+++ b/.github/workflows/release-connector-namespace.yml
@@ -58,6 +58,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Run this release workflow from the main branch so the workflow file itself has passed normal review." >&2
+            exit 1
+          fi
+
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
             echo "version must look like 1.0.0 or 1.0.0b34 and must not include a leading v" >&2
             exit 1
@@ -105,6 +110,25 @@ jobs:
             echo "Tag $TAG already exists. Refusing to attach a new release to an existing protected tag." >&2
             exit 1
           fi
+      - name: Verify target ref is on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REF: ${{ inputs.target_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TARGET_REF}")"
+          target_sha="$(echo "$target_json" | jq -r '.sha')"
+          compare_json="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${target_sha}...main")"
+          status="$(echo "$compare_json" | jq -r '.status')"
+
+          if [[ "$status" != "identical" && "$status" != "ahead" ]]; then
+            echo "target_ref ${TARGET_REF} (${target_sha}) is not reachable from main. Release tags must point at reviewed main history." >&2
+            exit 1
+          fi
+
+          echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Download and validate wheel
         env:

--- a/.github/workflows/release-connector-namespace.yml
+++ b/.github/workflows/release-connector-namespace.yml
@@ -43,6 +43,7 @@ jobs:
         id: inputs
         env:
           VERSION: ${{ inputs.version }}
+          TARGET_REF: ${{ inputs.target_ref }}
           NOTES_START_TAG: ${{ inputs.notes_start_tag }}
           PRERELEASE: ${{ inputs.prerelease }}
         shell: bash
@@ -56,6 +57,11 @@ jobs:
 
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
             echo "version must look like 1.0.0 or 1.0.0b34 and must not include a leading v" >&2
+            exit 1
+          fi
+
+          if [[ -z "${TARGET_REF}" || ! "${TARGET_REF}" =~ ^[A-Za-z0-9._/-]+$ || "${TARGET_REF}" == *..* || "${TARGET_REF}" == /* || "${TARGET_REF}" == */ || "${TARGET_REF}" == *//* ]]; then
+            echo "target_ref may contain only letters, numbers, '.', '_', '-', and '/', and must not contain '..', '//', or leading/trailing '/'" >&2
             exit 1
           fi
 
@@ -111,7 +117,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          target_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TARGET_REF}")"
+          encoded_target_ref="$(jq -rn --arg ref "${TARGET_REF}" '$ref|@uri')"
+          target_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_target_ref}")"
           target_sha="$(echo "${target_json}" | jq -r '.sha')"
           compare_json="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${target_sha}...main")"
           status="$(echo "${compare_json}" | jq -r '.status')"

--- a/.github/workflows/release-connector-namespace.yml
+++ b/.github/workflows/release-connector-namespace.yml
@@ -303,8 +303,24 @@ jobs:
           echo "${tag_json}" | jq '{ref, object}'
           tag_sha="$(echo "${tag_json}" | jq -r '.object.sha')"
           tag_type="$(echo "${tag_json}" | jq -r '.object.type')"
+          tag_target_sha="${tag_sha}"
 
-          if [[ "${tag_type}" == "commit" && "${tag_sha}" != "${TARGET_SHA}" ]]; then
-            echo "Release tag points to ${tag_sha}, expected ${TARGET_SHA}" >&2
+          if [[ "${tag_type}" == "tag" ]]; then
+            tag_object_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}")"
+            echo "${tag_object_json}" | jq '{tag_object_sha: .sha, object}'
+            tag_target_sha="$(echo "${tag_object_json}" | jq -r '.object.sha')"
+            tag_target_type="$(echo "${tag_object_json}" | jq -r '.object.type')"
+
+            if [[ "${tag_target_type}" != "commit" ]]; then
+              echo "Annotated release tag points to ${tag_target_type}, expected commit" >&2
+              exit 1
+            fi
+          elif [[ "${tag_type}" != "commit" ]]; then
+            echo "Release tag object type is ${tag_type}, expected commit or annotated tag" >&2
+            exit 1
+          fi
+
+          if [[ "${tag_target_sha}" != "${TARGET_SHA}" ]]; then
+            echo "Release tag points to ${tag_target_sha}, expected ${TARGET_SHA}" >&2
             exit 1
           fi

--- a/.github/workflows/release-connector-namespace.yml
+++ b/.github/workflows/release-connector-namespace.yml
@@ -1,24 +1,16 @@
-name: Release connector namespace CLI
+name: Release Connectors source archive
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Package version without leading v, for example 1.0.0b34"
+        description: "Release version without leading v, for example 1.0.0b34"
         required: true
         type: string
       target_ref:
         description: "Azure/Connectors ref or commit for the release tag"
         required: true
         default: "main"
-        type: string
-      wheel_url:
-        description: "HTTPS URL for connector_namespace-<version>-py3-none-any.whl from the approved build"
-        required: true
-        type: string
-      wheel_sha256:
-        description: "Expected SHA-256 of the wheel asset"
-        required: true
         type: string
       notes_start_tag:
         description: "Previous release tag for generated notes, for example v1.0.0b33"
@@ -32,14 +24,16 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 concurrency:
-  group: release-connector-namespace-${{ inputs.version }}
+  group: release-connectors-${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
   release:
-    name: Publish connector namespace CLI release
+    name: Publish Connectors source archive release
     runs-on: ubuntu-latest
     environment: release
     timeout-minutes: 30
@@ -49,49 +43,38 @@ jobs:
         id: inputs
         env:
           VERSION: ${{ inputs.version }}
-          TARGET_REF: ${{ inputs.target_ref }}
-          WHEEL_URL: ${{ inputs.wheel_url }}
-          WHEEL_SHA256: ${{ inputs.wheel_sha256 }}
           NOTES_START_TAG: ${{ inputs.notes_start_tag }}
           PRERELEASE: ${{ inputs.prerelease }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "Run this release workflow from the main branch so the workflow file itself has passed normal review." >&2
             exit 1
           fi
 
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
             echo "version must look like 1.0.0 or 1.0.0b34 and must not include a leading v" >&2
             exit 1
           fi
 
-          if [[ ! "$WHEEL_URL" =~ ^https:// ]]; then
-            echo "wheel_url must be an HTTPS URL" >&2
-            exit 1
-          fi
-
-          if [[ ! "$WHEEL_SHA256" =~ ^[0-9a-fA-F]{64}$ ]]; then
-            echo "wheel_sha256 must be a 64-character hex SHA-256" >&2
-            exit 1
-          fi
-
-          tag="v${VERSION}"
-          wheel_name="connector_namespace-${VERSION}-py3-none-any.whl"
-
-          if [[ -n "$NOTES_START_TAG" && ! "$NOTES_START_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
+          if [[ -n "${NOTES_START_TAG}" && ! "${NOTES_START_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([a-z][0-9]+)?$ ]]; then
             echo "notes_start_tag must look like v1.0.0 or v1.0.0b33" >&2
             exit 1
           fi
 
+          tag="v${VERSION}"
+          archive_name="Connectors-${VERSION}.zip"
+          archive_prefix="Connectors-${VERSION}/"
+
           {
-            echo "tag=$tag"
-            echo "wheel_name=$wheel_name"
-            echo "sha256_lower=${WHEEL_SHA256,,}"
-            echo "prerelease_flag=$([[ "$PRERELEASE" == "true" ]] && echo --prerelease || true)"
-          } >> "$GITHUB_OUTPUT"
+            echo "version=${VERSION}"
+            echo "tag=${tag}"
+            echo "archive_name=${archive_name}"
+            echo "archive_prefix=${archive_prefix}"
+            echo "prerelease_flag=$([[ "${PRERELEASE}" == "true" ]] && echo --prerelease || true)"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Ensure release tag does not already exist
         env:
@@ -101,16 +84,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Release $TAG already exists. Refusing to replace an immutable release." >&2
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists. Refusing to replace an immutable release." >&2
             exit 1
           fi
 
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists. Refusing to attach a new release to an existing protected tag." >&2
+            echo "Tag ${TAG} already exists. Refusing to attach a new release to an existing protected tag." >&2
             exit 1
           fi
+
       - name: Verify target ref is on main
+        id: target
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REF: ${{ inputs.target_ref }}
@@ -119,96 +104,129 @@ jobs:
           set -euo pipefail
 
           target_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TARGET_REF}")"
-          target_sha="$(echo "$target_json" | jq -r '.sha')"
+          target_sha="$(echo "${target_json}" | jq -r '.sha')"
           compare_json="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${target_sha}...main")"
-          status="$(echo "$compare_json" | jq -r '.status')"
+          status="$(echo "${compare_json}" | jq -r '.status')"
 
-          if [[ "$status" != "identical" && "$status" != "ahead" ]]; then
+          if [[ "${status}" != "identical" && "${status}" != "ahead" ]]; then
             echo "target_ref ${TARGET_REF} (${target_sha}) is not reachable from main. Release tags must point at reviewed main history." >&2
             exit 1
           fi
 
-          echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
+          echo "target_sha=${target_sha}" >> "${GITHUB_OUTPUT}"
 
-      - name: Download and validate wheel
+      - name: Checkout target commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ steps.target.outputs.target_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build source archive
+        id: archive
         env:
-          VERSION: ${{ inputs.version }}
-          WHEEL_URL: ${{ inputs.wheel_url }}
-          EXPECTED_SHA256: ${{ steps.inputs.outputs.sha256_lower }}
-          WHEEL_NAME: ${{ steps.inputs.outputs.wheel_name }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+          ARCHIVE_NAME: ${{ steps.inputs.outputs.archive_name }}
+          ARCHIVE_PREFIX: ${{ steps.inputs.outputs.archive_prefix }}
         shell: bash
         run: |
           set -euo pipefail
 
-          mkdir -p dist
-          curl --fail --location --retry 3 --retry-all-errors --proto '=https' --tlsv1.2 \
-            --output "dist/${WHEEL_NAME}" \
-            "$WHEEL_URL"
-
-          actual_sha256="$(sha256sum "dist/${WHEEL_NAME}" | awk '{print tolower($1)}')"
-          if [[ "$actual_sha256" != "$EXPECTED_SHA256" ]]; then
-            echo "Wheel SHA-256 mismatch. Expected $EXPECTED_SHA256, got $actual_sha256" >&2
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "${actual_sha}" != "${TARGET_SHA}" ]]; then
+            echo "Checked-out commit ${actual_sha} does not match target ${TARGET_SHA}" >&2
             exit 1
           fi
 
-          printf '%s  %s\n' "$actual_sha256" "$WHEEL_NAME" > "dist/${WHEEL_NAME}.sha256"
+          mkdir -p dist
+          git archive --format=zip --prefix="${ARCHIVE_PREFIX}" --output="dist/${ARCHIVE_NAME}" HEAD
 
           python - <<'PY'
-          import email.parser
           import os
           import pathlib
-          import sys
           import zipfile
 
-          version = os.environ["VERSION"]
-          wheel_path = pathlib.Path("dist") / os.environ["WHEEL_NAME"]
+          archive_path = pathlib.Path("dist") / os.environ["ARCHIVE_NAME"]
+          prefix = os.environ["ARCHIVE_PREFIX"]
+          required = {
+              prefix,
+              prefix + "README.md",
+              prefix + "SECURITY.md",
+              prefix + "SUPPORT.md",
+              prefix + "marketplace.json",
+              prefix + ".github/CODEOWNERS",
+              prefix + ".github/workflows/codeql.yml",
+              prefix + "plugin/skills/connectors/SKILL.md",
+              prefix + "plugin/skills/aca-sandboxes/SKILL.md",
+          }
 
-          with zipfile.ZipFile(wheel_path) as wheel:
-              metadata_names = [name for name in wheel.namelist() if name.endswith(".dist-info/METADATA")]
-              if len(metadata_names) != 1:
-                  raise SystemExit(f"Expected exactly one METADATA file, found {len(metadata_names)}")
+          with zipfile.ZipFile(archive_path) as archive:
+              names = set(archive.namelist())
 
-              metadata = email.parser.Parser().parsestr(wheel.read(metadata_names[0]).decode("utf-8"))
+          missing = sorted(required - names)
+          if missing:
+              raise SystemExit("Archive is missing expected repo entries: " + ", ".join(missing))
 
-          if metadata.get("Name") != "connector-namespace":
-              raise SystemExit(f"Unexpected package name: {metadata.get('Name')}")
+          forbidden_suffixes = (".whl", ".nupkg", ".tgz")
+          forbidden = sorted(name for name in names if name.endswith(forbidden_suffixes))
+          if forbidden:
+              raise SystemExit("Source archive unexpectedly contains package artifacts: " + ", ".join(forbidden[:10]))
 
-          if metadata.get("Version") != version:
-              raise SystemExit(f"Unexpected package version: {metadata.get('Version')} != {version}")
+          outside_prefix = sorted(name for name in names if not name.startswith(prefix))
+          if outside_prefix:
+              raise SystemExit("Archive contains entries outside expected prefix: " + ", ".join(outside_prefix[:10]))
           PY
+
+          archive_sha256="$(sha256sum "dist/${ARCHIVE_NAME}" | awk '{print tolower($1)}')"
+          printf '%s  %s\n' "${archive_sha256}" "${ARCHIVE_NAME}" > "dist/${ARCHIVE_NAME}.sha256"
+
+          {
+            echo "archive_path=dist/${ARCHIVE_NAME}"
+            echo "archive_sha256=${archive_sha256}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Attest source archive
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: ${{ steps.archive.outputs.archive_path }}
 
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.inputs.outputs.tag }}
-          TARGET_REF: ${{ inputs.target_ref }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
           NOTES_START_TAG: ${{ inputs.notes_start_tag }}
-          WHEEL_NAME: ${{ steps.inputs.outputs.wheel_name }}
+          ARCHIVE_NAME: ${{ steps.inputs.outputs.archive_name }}
+          ARCHIVE_SHA256: ${{ steps.archive.outputs.archive_sha256 }}
         shell: bash
         run: |
           set -euo pipefail
 
           request_file="$(mktemp)"
-          if [[ -n "$NOTES_START_TAG" ]]; then
-            jq -n --arg tag "$TAG" --arg target "$TARGET_REF" --arg previous "$NOTES_START_TAG" \
-              '{tag_name:$tag,target_commitish:$target,previous_tag_name:$previous}' > "$request_file"
+          if [[ -n "${NOTES_START_TAG}" ]]; then
+            jq -n --arg tag "${TAG}" --arg target "${TARGET_SHA}" --arg previous "${NOTES_START_TAG}" \
+              '{tag_name:$tag,target_commitish:$target,previous_tag_name:$previous}' > "${request_file}"
           else
-            jq -n --arg tag "$TAG" --arg target "$TARGET_REF" \
-              '{tag_name:$tag,target_commitish:$target}' > "$request_file"
+            jq -n --arg tag "${TAG}" --arg target "${TARGET_SHA}" \
+              '{tag_name:$tag,target_commitish:$target}' > "${request_file}"
           fi
 
           gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            --input "$request_file" \
+            --input "${request_file}" \
             --jq '.body' > release-notes.generated.md
 
           {
-            echo "Release artifact: ${WHEEL_NAME}"
+            echo "Release artifact: ${ARCHIVE_NAME}"
+            echo
+            echo "Source commit: ${TARGET_SHA}"
             echo
             echo "SHA-256:"
             echo
             echo '```text'
-            cat "dist/${WHEEL_NAME}.sha256"
+            cat "dist/${ARCHIVE_NAME}.sha256"
             echo '```'
+            echo
+            echo "This source archive is built from reviewed repository content by GitHub Actions and attested by the workflow run."
             echo
             cat release-notes.generated.md
           } > release-notes.md
@@ -217,47 +235,67 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.inputs.outputs.tag }}
-          TARGET_REF: ${{ inputs.target_ref }}
-          WHEEL_NAME: ${{ steps.inputs.outputs.wheel_name }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+          ARCHIVE_NAME: ${{ steps.inputs.outputs.archive_name }}
           PRERELEASE_FLAG: ${{ steps.inputs.outputs.prerelease_flag }}
         shell: bash
         run: |
           set -euo pipefail
 
-          gh release create "$TAG" \
-            "dist/${WHEEL_NAME}" \
-            "dist/${WHEEL_NAME}.sha256" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$TARGET_REF" \
+          gh release create "${TAG}" \
+            "dist/${ARCHIVE_NAME}" \
+            "dist/${ARCHIVE_NAME}.sha256" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${TARGET_SHA}" \
             --title "${TAG} (preview)" \
             --latest=false \
             --fail-on-no-commits \
             --notes-file release-notes.md \
-            $PRERELEASE_FLAG
+            ${PRERELEASE_FLAG}
 
       - name: Read back release protections
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.inputs.outputs.tag }}
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+          ARCHIVE_NAME: ${{ steps.inputs.outputs.archive_name }}
         shell: bash
         run: |
           set -euo pipefail
 
           release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"
-          echo "$release_json" | jq '{tag_name, draft, prerelease, immutable, target_commitish, assets: [.assets[].name]}'
+          echo "${release_json}" | jq '{tag_name, draft, prerelease, immutable, target_commitish, assets: [.assets[].name]}'
 
-          immutable="$(echo "$release_json" | jq -r '.immutable')"
-          draft="$(echo "$release_json" | jq -r '.draft')"
+          immutable="$(echo "${release_json}" | jq -r '.immutable')"
+          draft="$(echo "${release_json}" | jq -r '.draft')"
+          assets="$(echo "${release_json}" | jq -r '[.assets[].name] | join("\n")')"
 
-          if [[ "$draft" != "false" ]]; then
-            echo "Published release unexpectedly reports draft=$draft" >&2
+          if [[ "${draft}" != "false" ]]; then
+            echo "Published release unexpectedly reports draft=${draft}" >&2
             exit 1
           fi
 
-          if [[ "$immutable" != "true" ]]; then
+          if [[ "${immutable}" != "true" ]]; then
             echo "Published release did not report immutable=true" >&2
             exit 1
           fi
 
-          gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" \
-            --jq '{ref, object}'
+          if ! grep -Fxq "${ARCHIVE_NAME}" <<< "${assets}"; then
+            echo "Published release is missing ${ARCHIVE_NAME}" >&2
+            exit 1
+          fi
+
+          if ! grep -Fxq "${ARCHIVE_NAME}.sha256" <<< "${assets}"; then
+            echo "Published release is missing ${ARCHIVE_NAME}.sha256" >&2
+            exit 1
+          fi
+
+          tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}")"
+          echo "${tag_json}" | jq '{ref, object}'
+          tag_sha="$(echo "${tag_json}" | jq -r '.object.sha')"
+          tag_type="$(echo "${tag_json}" | jq -r '.object.type')"
+
+          if [[ "${tag_type}" == "commit" && "${tag_sha}" != "${TARGET_SHA}" ]]; then
+            echo "Release tag points to ${tag_sha}, expected ${TARGET_SHA}" >&2
+            exit 1
+          fi

--- a/.github/workflows/release-connector-namespace.yml
+++ b/.github/workflows/release-connector-namespace.yml
@@ -67,13 +67,21 @@ jobs:
           tag="v${VERSION}"
           archive_name="Connectors-${VERSION}.zip"
           archive_prefix="Connectors-${VERSION}/"
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            prerelease_flag="--prerelease"
+            release_title="${tag} (preview)"
+          else
+            prerelease_flag=""
+            release_title="${tag}"
+          fi
 
           {
             echo "version=${VERSION}"
             echo "tag=${tag}"
             echo "archive_name=${archive_name}"
             echo "archive_prefix=${archive_prefix}"
-            echo "prerelease_flag=$([[ "${PRERELEASE}" == "true" ]] && echo --prerelease || true)"
+            echo "prerelease_flag=${prerelease_flag}"
+            echo "release_title=${release_title}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Ensure release tag does not already exist
@@ -141,7 +149,7 @@ jobs:
           mkdir -p dist
           git archive --format=zip --prefix="${ARCHIVE_PREFIX}" --output="dist/${ARCHIVE_NAME}" HEAD
 
-          python - <<'PY'
+          python3 - <<'PY'
           import os
           import pathlib
           import zipfile
@@ -238,6 +246,7 @@ jobs:
           TARGET_SHA: ${{ steps.target.outputs.target_sha }}
           ARCHIVE_NAME: ${{ steps.inputs.outputs.archive_name }}
           PRERELEASE_FLAG: ${{ steps.inputs.outputs.prerelease_flag }}
+          RELEASE_TITLE: ${{ steps.inputs.outputs.release_title }}
         shell: bash
         run: |
           set -euo pipefail
@@ -247,7 +256,7 @@ jobs:
             "dist/${ARCHIVE_NAME}.sha256" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${TARGET_SHA}" \
-            --title "${TAG} (preview)" \
+            --title "${RELEASE_TITLE}" \
             --latest=false \
             --fail-on-no-commits \
             --notes-file release-notes.md \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ After publishing a release, verify:
 ```powershell
 gh api repos/Azure/Connectors/releases/tags/v<version>
 gh api repos/Azure/Connectors/git/ref/tags/v<version>
-gh api repos/Azure/Connectors/rulesets/18361079
+gh api repos/Azure/Connectors/rulesets --jq '.[] | select(.target == "tag") | {name, enforcement, conditions, rules}'
 gh api repos/Azure/Connectors/environments/release
 ```
 
@@ -79,9 +79,11 @@ Example command shape:
 ```powershell
 git archive --format=zip --prefix="Connectors-<version>/" --output="Connectors-<version>.zip" <commit-sha>
 Get-FileHash -Algorithm SHA256 .\Connectors-<version>.zip
+git tag v<version> <commit-sha>
+git push origin v<version>
 gh release create v<version> `
   --repo Azure/Connectors `
-  --target <commit-sha> `
+  --verify-tag `
   --title "v<version> (preview)" `
   --prerelease `
   --latest=false `
@@ -90,7 +92,7 @@ gh release create v<version> `
   .\Connectors-<version>.zip.sha256
 ```
 
-`gh release create` has no dry-run mode. If the tag does not already exist, it creates the tag automatically unless `--verify-tag` is supplied.
+`gh release create` has no dry-run mode. The fallback command uses `--verify-tag` so it fails instead of creating an unintended tag.
 
 ## When additional build provenance is needed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,84 @@
+# Releasing
+
+This repository currently publishes public preview connector artifacts through GitHub Releases.
+
+## Current release model
+
+Releases are tag-based:
+
+- Release tags use the `v<version>` shape, for example `v1.0.0b33`.
+- The public preview CLI documentation downloads wheel assets from GitHub release tag URLs.
+- Each release tag is expected to publish a matching wheel asset named `connector_namespace-<version>-py3-none-any.whl`.
+
+Do not create disposable `v*` tags for testing. Release tags are protected and are expected to represent real preview artifacts.
+
+## Security controls
+
+The repository has release-tag protection and future release immutability enabled:
+
+- The active tag ruleset protects `refs/tags/v*` from deletion and non-fast-forward updates.
+- Published releases are expected to become immutable after publication.
+- Existing older releases may not show as immutable if they were published before immutability was enabled.
+
+After publishing a release, verify:
+
+```powershell
+gh api repos/Azure/Connectors/releases/tags/v<version>
+gh api repos/Azure/Connectors/git/ref/tags/v<version>
+gh api repos/Azure/Connectors/rulesets/18361079
+```
+
+Expected evidence:
+
+- The release exists and is not a draft.
+- Preview releases use `prerelease=true`.
+- New releases should report `immutable=true`.
+- The tag ref points to the intended commit or annotated tag object.
+- The tag ruleset remains active for `refs/tags/v*` with `deletion` and `non_fast_forward` rules.
+
+## Preferred release process
+
+A workflow-backed release is safer than publishing artifacts from an individual account because it gives the repo a repeatable managed identity, auditable logs, constrained permissions, and a path to provenance or attestation.
+
+The preferred future process is:
+
+1. Build the wheel in GitHub Actions from the selected commit.
+2. Create the release as a draft.
+3. Upload all assets while the release is still a draft.
+4. Publish the release only after all assets are attached.
+5. Read back the release, tag, and asset metadata.
+
+A release workflow should use least-privilege permissions, for example:
+
+```yaml
+permissions:
+  contents: write
+  id-token: write
+```
+
+Use `contents: write` only for the release job that creates the tag or release. Use `id-token: write` only if provenance, artifact attestations, or trusted publishing are enabled.
+
+## Manual release fallback
+
+Until a release workflow exists, a maintainer may publish a release manually only after producing the expected wheel asset from the owner-approved build process.
+
+Example command shape:
+
+```powershell
+gh release create v<version> `
+  --repo Azure/Connectors `
+  --target <commit-sha> `
+  --title "v<version> (preview)" `
+  --prerelease `
+  --latest=false `
+  --notes-file <release-notes.md> `
+  <path-to-connector_namespace-<version>-py3-none-any.whl>
+```
+
+`gh release create` has no dry-run mode. If the tag does not already exist, it creates the tag automatically unless `--verify-tag` is supplied.
+
+## When a release workflow applies
+
+A release workflow does apply to this repository for any generated artifact such as the connector namespace wheel. The repository also contains documentation and plugin skill content; those files alone do not require a package publishing workflow. The wheel asset does.
+
+If a future release contains only documentation or plugin skill text with no generated artifact, the release owner should decide whether a GitHub Release is needed at all. If a GitHub Release is used, keep the same tag and immutability validation steps.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,7 +61,16 @@ Before running the workflow:
 4. Confirm the requested `version` matches the wheel metadata.
 5. Confirm `target_ref` points to the repository commit that should own the release tag.
 
-The release job uses the `release` environment. Configure that environment with required reviewers before relying on it as an approval gate.
+The release job uses the `release` environment. This is the native GitHub Actions approval hook, but it is only an actual approval gate after the repository environment is configured.
+
+Required environment setting:
+
+- Environment name: `release`
+- Required reviewers: a small maintainer/release-owner team, for example `@Azure/azure-connectors-contributors` until a narrower release-owner team exists
+- Prevent self-review: enabled, if available in the repository UI
+- Deployment branches: restrict to `main`, or protected branches that include `main`
+
+A configuration attempt from the audit session failed with `Must have admin rights to Repository`, so an admin/JIT owner must create or update this environment before the workflow is used for production release validation.
 
 ## Why the workflow is safer
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This repository currently publishes public preview connector artifacts through GitHub Releases.
+This repository publishes public preview connector artifacts through GitHub Releases.
 
 ## Current release model
 
@@ -36,31 +36,51 @@ Expected evidence:
 - The tag ref points to the intended commit or annotated tag object.
 - The tag ruleset remains active for `refs/tags/v*` with `deletion` and `non_fast_forward` rules.
 
-## Preferred release process
+## Release workflow
+
+Use the **Release connector namespace CLI** workflow for new wheel releases.
+
+The workflow publishes the release with `GITHUB_TOKEN` instead of an individual account. It validates the requested version, release tag, wheel file name, wheel SHA-256, and wheel package metadata before creating the GitHub Release. After publication, it reads back the release and fails if the new release does not report `immutable=true`.
+
+Required workflow inputs:
+
+| Input | Purpose |
+| --- | --- |
+| `version` | Package version without a leading `v`, for example `1.0.0b34` |
+| `target_ref` | Azure/Connectors ref or commit used for the release tag |
+| `wheel_url` | HTTPS URL for `connector_namespace-<version>-py3-none-any.whl` from the approved build |
+| `wheel_sha256` | Expected SHA-256 for the wheel |
+| `notes_start_tag` | Previous release tag used for generated notes |
+| `prerelease` | Whether the GitHub Release should be marked as a prerelease |
+
+Before running the workflow:
+
+1. Produce the wheel from the owner-approved connector namespace CLI build.
+2. Record the source/build run that produced the wheel.
+3. Compute and review the wheel SHA-256.
+4. Confirm the requested `version` matches the wheel metadata.
+5. Confirm `target_ref` points to the repository commit that should own the release tag.
+
+The release job uses the `release` environment. Configure that environment with required reviewers before relying on it as an approval gate.
+
+## Why the workflow is safer
 
 A workflow-backed release is safer than publishing artifacts from an individual account because it gives the repo a repeatable managed identity, auditable logs, constrained permissions, and a path to provenance or attestation.
 
-The preferred future process is:
+This repository currently does not contain the generated `azext_connector_namespace` source that appears inside the published wheel. Until that source and build are available in this repository, the release workflow cannot truthfully claim to build the wheel from local source. The current workflow therefore treats the wheel as an input from the approved build and validates it before publication.
 
-1. Build the wheel in GitHub Actions from the selected commit.
-2. Create the release as a draft.
-3. Upload all assets while the release is still a draft.
-4. Publish the release only after all assets are attached.
-5. Read back the release, tag, and asset metadata.
+The stronger future state is:
 
-A release workflow should use least-privilege permissions, for example:
-
-```yaml
-permissions:
-  contents: write
-  id-token: write
-```
-
-Use `contents: write` only for the release job that creates the tag or release. Use `id-token: write` only if provenance, artifact attestations, or trusted publishing are enabled.
+1. Build the wheel in GitHub Actions from pinned, repository-owned source.
+2. Create provenance or artifact attestations for that build.
+3. Create the release as a draft.
+4. Upload all assets while the release is still a draft.
+5. Publish the release only after all assets are attached.
+6. Read back the release, tag, asset, and immutability metadata.
 
 ## Manual release fallback
 
-Until a release workflow exists, a maintainer may publish a release manually only after producing the expected wheel asset from the owner-approved build process.
+Manual publishing should be treated as break-glass. Until the release workflow is fully adopted, a maintainer may publish a release manually only after producing the expected wheel asset from the owner-approved build process.
 
 Example command shape:
 
@@ -79,6 +99,6 @@ gh release create v<version> `
 
 ## When a release workflow applies
 
-A release workflow does apply to this repository for any generated artifact such as the connector namespace wheel. The repository also contains documentation and plugin skill content; those files alone do not require a package publishing workflow. The wheel asset does.
+A release workflow applies to this repository for generated artifacts such as the connector namespace wheel. The repository also contains documentation and plugin skill content; those files alone do not require package publishing automation. The wheel asset does.
 
 If a future release contains only documentation or plugin skill text with no generated artifact, the release owner should decide whether a GitHub Release is needed at all. If a GitHub Release is used, keep the same tag and immutability validation steps.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,7 +34,7 @@ Expected evidence:
 
 - The release exists and is not a draft.
 - Preview releases use `prerelease=true`.
-- New releases should report `immutable=true`.
+- New releases must report `immutable=true`.
 - The release contains `Connectors-<version>.zip` and `Connectors-<version>.zip.sha256` assets.
 - The tag ref points to the intended commit or annotated tag object.
 - The tag ruleset remains active for `refs/tags/v*` with `deletion` and `non_fast_forward` rules.
@@ -70,29 +70,11 @@ The source archive workflow applies to this repository because the release conte
 
 If future releases include a generated wheel or package again, the wheel source and deterministic build must be added to this repository or to another trusted workflow. Do not publish opaque externally built wheels as KPI-compliant artifacts.
 
-## Manual release fallback
+## No manual release fallback
 
-Manual publishing should be treated as break-glass. Until the release workflow is fully adopted, a maintainer may publish a release manually only when the release workflow is unavailable and the same source archive, checksum, release tag, and immutability evidence can be reproduced and recorded.
+Do not publish releases manually through the GitHub UI or `gh release create`. The approved path is the release workflow because it is reviewed, environment-gated, checksummed, attested, and validated after publication.
 
-Example command shape:
-
-```powershell
-git archive --format=zip --prefix="Connectors-<version>/" --output="Connectors-<version>.zip" <commit-sha>
-Get-FileHash -Algorithm SHA256 .\Connectors-<version>.zip
-git tag v<version> <commit-sha>
-git push origin v<version>
-gh release create v<version> `
-  --repo Azure/Connectors `
-  --verify-tag `
-  --title "v<version> (preview)" `
-  --prerelease `
-  --latest=false `
-  --notes-file <release-notes.md> `
-  .\Connectors-<version>.zip `
-  .\Connectors-<version>.zip.sha256
-```
-
-`gh release create` has no dry-run mode. The fallback command uses `--verify-tag` so it fails instead of creating an unintended tag.
+GitHub release environments protect workflow deployments; they do not, by themselves, gate direct UI or API release creation. If a stronger technical block is required, combine least-privilege repository access with release-tag creation restrictions that still allow the approved workflow identity to create release tags. Until that is configured, manual release publishing remains prohibited by repo process.
 
 ## When additional build provenance is needed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,8 @@ This repository publishes public preview connector artifacts through GitHub Rele
 Releases are tag-based:
 
 - Release tags use the `v<version>` shape, for example `v1.0.0b33`.
-- GitHub automatically exposes a source-code zip for each tag. A downloaded archive such as `Connectors-1.0.0b33.zip` is a zip of repository content under a top-level `Connectors-<version>/` folder.
-- The release workflow also uploads an explicit `Connectors-<version>.zip` source archive plus a `.sha256` file so the artifact, checksum, workflow run, and attestation are all visible in the release.
+- GitHub automatically exposes source-code archives for each tag; their download names and internal top-level folder names are controlled by GitHub.
+- The release workflow also uploads an explicit deterministic `Connectors-<version>.zip` source archive plus a `.sha256` file so the artifact, checksum, workflow run, and attestation are all visible in the release.
 
 Do not create disposable `v*` tags for testing. Release tags are protected and are expected to represent real preview artifacts.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,17 +7,18 @@ This repository publishes public preview connector artifacts through GitHub Rele
 Releases are tag-based:
 
 - Release tags use the `v<version>` shape, for example `v1.0.0b33`.
-- The public preview CLI documentation downloads wheel assets from GitHub release tag URLs.
-- Each release tag is expected to publish a matching wheel asset named `connector_namespace-<version>-py3-none-any.whl`.
+- GitHub automatically exposes a source-code zip for each tag. A downloaded archive such as `Connectors-1.0.0b33.zip` is a zip of repository content under a top-level `Connectors-<version>/` folder.
+- The release workflow also uploads an explicit `Connectors-<version>.zip` source archive plus a `.sha256` file so the artifact, checksum, workflow run, and attestation are all visible in the release.
 
 Do not create disposable `v*` tags for testing. Release tags are protected and are expected to represent real preview artifacts.
 
 ## Security controls
 
-The repository has release-tag protection and future release immutability enabled:
+The repository has release-tag protection, release immutability, and a release approval environment:
 
 - The active tag ruleset protects `refs/tags/v*` from deletion and non-fast-forward updates.
 - Published releases are expected to become immutable after publication.
+- The `release` environment requires approval from `@Azure/azure-connectors-contributors`, prevents self-review, disables admin bypass, and is restricted to protected branches.
 - Existing older releases may not show as immutable if they were published before immutability was enabled.
 
 After publishing a release, verify:
@@ -26,6 +27,7 @@ After publishing a release, verify:
 gh api repos/Azure/Connectors/releases/tags/v<version>
 gh api repos/Azure/Connectors/git/ref/tags/v<version>
 gh api repos/Azure/Connectors/rulesets/18361079
+gh api repos/Azure/Connectors/environments/release
 ```
 
 Expected evidence:
@@ -33,67 +35,50 @@ Expected evidence:
 - The release exists and is not a draft.
 - Preview releases use `prerelease=true`.
 - New releases should report `immutable=true`.
+- The release contains `Connectors-<version>.zip` and `Connectors-<version>.zip.sha256` assets.
 - The tag ref points to the intended commit or annotated tag object.
 - The tag ruleset remains active for `refs/tags/v*` with `deletion` and `non_fast_forward` rules.
+- The `release` environment still requires reviewers and prevents self-review.
 
 ## Release workflow
 
-Use the **Release connector namespace CLI** workflow for new wheel releases.
+Use the **Release Connectors source archive** workflow for new releases.
 
-The workflow publishes the release with `GITHUB_TOKEN` instead of an individual account. It validates the requested version, release tag, wheel file name, wheel SHA-256, and wheel package metadata before creating the GitHub Release. After publication, it reads back the release and fails if the new release does not report `immutable=true`.
+The workflow publishes the release with `GITHUB_TOKEN` instead of an individual account. It validates the requested version and tag, verifies that the target commit is reachable from `main`, checks out that exact commit, builds a source archive with `git archive`, emits a SHA-256 file, creates a build-provenance attestation, publishes the release, and reads back the release immutability/tag metadata.
 
 Required workflow inputs:
 
 | Input | Purpose |
 | --- | --- |
-| `version` | Package version without a leading `v`, for example `1.0.0b34` |
-| `target_ref` | Azure/Connectors ref or commit used for the release tag |
-| `wheel_url` | HTTPS URL for `connector_namespace-<version>-py3-none-any.whl` from the approved build |
-| `wheel_sha256` | Expected SHA-256 for the wheel |
+| `version` | Release version without a leading `v`, for example `1.0.0b34` |
+| `target_ref` | Azure/Connectors ref or commit used for the release tag; must be reachable from `main` |
 | `notes_start_tag` | Previous release tag used for generated notes |
 | `prerelease` | Whether the GitHub Release should be marked as a prerelease |
 
 Before running the workflow:
 
-1. Produce the wheel from the owner-approved connector namespace CLI build.
-2. Record the source/build run that produced the wheel.
-3. Compute and review the wheel SHA-256.
-4. Confirm the requested `version` matches the wheel metadata.
-5. Confirm `target_ref` points to the repository commit that should own the release tag.
-
-The release job uses the `release` environment. This is the native GitHub Actions approval hook, but it is only an actual approval gate after the repository environment is configured.
-
-Required environment setting:
-
-- Environment name: `release`
-- Required reviewers: a small maintainer/release-owner team, for example `@Azure/azure-connectors-contributors` until a narrower release-owner team exists
-- Prevent self-review: enabled, if available in the repository UI
-- Deployment branches: restrict to `main`, or protected branches that include `main`
-
-A configuration attempt from the audit session failed with `Must have admin rights to Repository`, so an admin/JIT owner must create or update this environment before the workflow is used for production release validation.
+1. Confirm all release content is merged to `main` through a reviewed PR.
+2. Confirm `target_ref` points to the reviewed `main` commit that should own the release tag.
+3. Confirm the release environment approval is still configured.
+4. Run the workflow from the `main` branch.
 
 ## Why the workflow is safer
 
-A workflow-backed release is safer than publishing artifacts from an individual account because it gives the repo a repeatable managed identity, auditable logs, constrained permissions, and a path to provenance or attestation.
+A workflow-backed release is safer than publishing artifacts from an individual account because it gives the repo a repeatable managed identity, auditable logs, constrained permissions, required approval, and provenance for the source archive.
 
-This repository currently does not contain the generated `azext_connector_namespace` source that appears inside the published wheel. Until that source and build are available in this repository, the release workflow cannot truthfully claim to build the wheel from local source. The current workflow therefore treats the wheel as an input from the approved build and validates it before publication.
+The source archive workflow applies to this repository because the release content is repository content: documentation, plugin skill files, and public preview CLI materials. The downloaded `Connectors-1.0.0b33.zip` archive is not the generated `azext_connector_namespace` wheel; it is a source-code archive of this repository.
 
-The stronger future state is:
-
-1. Build the wheel in GitHub Actions from pinned, repository-owned source.
-2. Create provenance or artifact attestations for that build.
-3. Create the release as a draft.
-4. Upload all assets while the release is still a draft.
-5. Publish the release only after all assets are attached.
-6. Read back the release, tag, asset, and immutability metadata.
+If future releases include a generated wheel or package again, the wheel source and deterministic build must be added to this repository or to another trusted workflow. Do not publish opaque externally built wheels as KPI-compliant artifacts.
 
 ## Manual release fallback
 
-Manual publishing should be treated as break-glass. Until the release workflow is fully adopted, a maintainer may publish a release manually only after producing the expected wheel asset from the owner-approved build process.
+Manual publishing should be treated as break-glass. Until the release workflow is fully adopted, a maintainer may publish a release manually only when the release workflow is unavailable and the same source archive, checksum, release tag, and immutability evidence can be reproduced and recorded.
 
 Example command shape:
 
 ```powershell
+git archive --format=zip --prefix="Connectors-<version>/" --output="Connectors-<version>.zip" <commit-sha>
+Get-FileHash -Algorithm SHA256 .\Connectors-<version>.zip
 gh release create v<version> `
   --repo Azure/Connectors `
   --target <commit-sha> `
@@ -101,13 +86,20 @@ gh release create v<version> `
   --prerelease `
   --latest=false `
   --notes-file <release-notes.md> `
-  <path-to-connector_namespace-<version>-py3-none-any.whl>
+  .\Connectors-<version>.zip `
+  .\Connectors-<version>.zip.sha256
 ```
 
 `gh release create` has no dry-run mode. If the tag does not already exist, it creates the tag automatically unless `--verify-tag` is supplied.
 
-## When a release workflow applies
+## When additional build provenance is needed
 
-A release workflow applies to this repository for generated artifacts such as the connector namespace wheel. The repository also contains documentation and plugin skill content; those files alone do not require package publishing automation. The wheel asset does.
+The source archive workflow is sufficient for releases whose deliverable is repository content. It is not sufficient for a generated package that is not built from this repository.
 
-If a future release contains only documentation or plugin skill text with no generated artifact, the release owner should decide whether a GitHub Release is needed at all. If a GitHub Release is used, keep the same tag and immutability validation steps.
+If `connector_namespace-<version>-py3-none-any.whl` or another generated package is published in a future release, the KPI-compliant path is:
+
+1. Put the authoritative package source under reviewed source control.
+2. Build the package inside a trusted workflow.
+3. Attest the built package.
+4. Publish the attested package through the release workflow.
+5. Read back release immutability, tag protection, artifact names, checksums, and attestations.


### PR DESCRIPTION
## Summary

Adds a managed GitHub Actions release path for Azure/Connectors source-archive releases.

This replaces individual-account release publishing with a reviewed workflow that:

- Runs only from `main` and uses the `release` environment.
- Requires a target commit reachable from reviewed `main` history.
- Refuses to publish if the `v*` tag or release already exists.
- Builds `Connectors-<version>.zip` from repository content with `git archive`.
- Writes `Connectors-<version>.zip.sha256`.
- Creates a GitHub build-provenance attestation for the archive.
- Publishes the release with `GITHUB_TOKEN`.
- Reads back the release, assets, tag ref, and `immutable=true` state.

Also adds `RELEASING.md` so future maintainers have the release model, security controls, validation commands, and the wheel/provenance caveat in-repo.

## Security controls configured outside this PR

The `release` environment now exists on `Azure/Connectors` and was read back with:

- Required reviewer team: `@Azure/azure-connectors-contributors` (`id=17733643`).
- `prevent_self_review=true`.
- `can_admins_bypass=false`.
- Branch policy restricted to protected branches.

The repo also has the existing `immutable release tags` ruleset for `refs/tags/v*` and release immutability enabled.

## Validation

- Parsed `.github/workflows/release-connector-namespace.yml` successfully as YAML.
- Verified expected workflow shape: 9 release steps, `environment: release`, `contents: write`, `id-token: write`, and `attestations: write`.
- Verified `uses:` references are pinned to 40-character SHAs:
  - `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (`v7`)
  - `actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a` (`v3`)
- Simulated the source archive from this PR branch with `git archive --format=zip --prefix=Connectors-1.0.0b34/`.
- Archive validation result: 78 entries, one top-level `Connectors-1.0.0b34` folder, required repo entries present, no `.whl`, `.nupkg`, or `.tgz` artifacts, no entries outside the expected prefix.
- Compared with the locally inspected prior archive `Connectors-1.0.0b33.zip`: prior archive had 76 entries, top-level `Connectors-1.0.0b33`, included `.github/workflows`, and contained no wheel. The two extra entries in the simulated archive are this PR's workflow and `RELEASING.md`.

## Caveat

This PR makes the source-archive release path KPI-compliant after merge and first workflow-run validation. The previously uploaded `connector_namespace-1.0.0b33-py3-none-any.whl` asset is a separate generated package artifact; if future releases need a wheel, the authoritative source and deterministic wheel build need to be added to a trusted workflow before publishing it as KPI-compliant.