### PR TITLE
Add CodeQL Python coverage and ShellCheck/PSScriptAnalyzer/ruff lint gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,9 +36,9 @@ jobs:
         language:
           # Languages will be auto-detected. To add manually, list here, e.g.:
           # - javascript-typescript
-          # - python
           # - csharp
           - actions
+          - python
 
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
           $scripts = git ls-files '*.ps1'
           if (-not $scripts) {
             Write-Output "No PowerShell scripts found."
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install ruff
-        run: python3 -m pip install --user ruff
+        run: python3 -m pip install --user ruff==0.15.14
 
       - name: Run ruff check
         run: python3 -m ruff check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,10 @@
 # Static-analysis lint gates for shell, PowerShell, and Python sources.
 #
-# Complements codeql.yml (SAST). Uses only tools preinstalled on the
-# ubuntu-latest runner image (shellcheck, pwsh) or installed via pip
-# (ruff), so there is no third-party Action to SHA-pin for this workflow.
+# Complements codeql.yml (SAST). ShellCheck is preinstalled on the
+# ubuntu-latest runner image; PSScriptAnalyzer and ruff are installed at
+# pinned versions from their official registries (PowerShell Gallery, pip)
+# rather than via a third-party GitHub Action, so there is nothing here
+# that needs SHA-pinning.
 #
 # Docs:
 #   https://www.shellcheck.net/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,81 @@
+# Static-analysis lint gates for shell, PowerShell, and Python sources.
+#
+# Complements codeql.yml (SAST). Uses only tools preinstalled on the
+# ubuntu-latest runner image (shellcheck, pwsh) or installed via pip
+# (ruff), so there is no third-party Action to SHA-pin for this workflow.
+#
+# Docs:
+#   https://www.shellcheck.net/
+#   https://github.com/PowerShell/PSScriptAnalyzer
+#   https://docs.astral.sh/ruff/
+
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Run ShellCheck
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t scripts < <(git ls-files '*.sh')
+          if [ "${#scripts[@]}" -eq 0 ]; then
+            echo "No shell scripts found."
+            exit 0
+          fi
+          shellcheck "${scripts[@]}"
+
+  psscriptanalyzer:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          $scripts = git ls-files '*.ps1'
+          if (-not $scripts) {
+            Write-Output "No PowerShell scripts found."
+            exit 0
+          }
+          $results = Invoke-ScriptAnalyzer -Path $scripts -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Warning,Error
+          if ($results) {
+            $results | Format-Table -AutoSize
+            throw "PSScriptAnalyzer found $($results.Count) issue(s)."
+          }
+
+  ruff:
+    name: Ruff (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install ruff
+        run: python3 -m pip install --user ruff
+
+      - name: Run ruff check
+        run: python3 -m ruff check .

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,10 @@
+@{
+    # This repo ships a single interactive installer script (install.ps1)
+    # invoked via `irm ... | iex`. Console-only output via Write-Host is
+    # intentional there (output is not meant to be captured or piped), so
+    # that specific rule is excluded repo-wide rather than suppressed
+    # per-line.
+    ExcludeRules = @(
+        "PSAvoidUsingWriteHost"
+    )
+}

--- a/plugin/skills/aca-sandboxes/scripts/trigger-getting-started.py
+++ b/plugin/skills/aca-sandboxes/scripts/trigger-getting-started.py
@@ -36,7 +36,7 @@ parser.add_argument("--cleanup", action="store_true", help="Delete trigger after
 args = parser.parse_args()
 
 account = json.loads(subprocess.run(
-    ["az", "account", "show", "-o", "json"],
+    ["az", "account", "show", "-o", "json"],  # noqa: S607 -- fixed args, PATH-resolved az CLI
     capture_output=True, text=True, check=True).stdout)
 
 subscription_id = account["id"]
@@ -76,7 +76,9 @@ def az_rest(method, url, body=None, resource=None, ignore_errors=False):
         tmp.close()
         cmd += ["--body", f"@{tmp.name}"]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        # cmd is always a fixed "az ..." argument list built above -- never shell=True
+        # or untrusted input, so this is not a command-injection risk.
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603
         return json.loads(result.stdout) if result.stdout.strip() else {}
     except subprocess.CalledProcessError as e:
         if ignore_errors:
@@ -94,10 +96,10 @@ def ensure_user_acl(conn_arm_base, conn_location):
     Required to call the metadata URL with the API Hub audience.
     """
     user_oid = subprocess.run(
-        ["az", "ad", "signed-in-user", "show", "--query", "id", "-o", "tsv"],
+        ["az", "ad", "signed-in-user", "show", "--query", "id", "-o", "tsv"],  # noqa: S607
         capture_output=True, text=True, check=True).stdout.strip()
     tenant_id = subprocess.run(
-        ["az", "account", "show", "--query", "tenantId", "-o", "tsv"],
+        ["az", "account", "show", "--query", "tenantId", "-o", "tsv"],  # noqa: S607
         capture_output=True, text=True, check=True).stdout.strip()
     acl_url = f"{conn_arm_base}/accessPolicies/{user_oid}?{API_VERSION}"
     # GET first — only create if missing
@@ -191,9 +193,9 @@ if trigger_type.lower() in ("polling", "batch", "single"):
     # NOTE: To determine if this is a recurrence trigger, check the Swagger for
     # the operation. If it lacks both x-ms-notification and x-ms-notification-content,
     # it's a recurrence/polling trigger regardless of single/batch.
-    print(f"\n  ℹ️  Check Swagger for this operation to determine if it's a recurrence trigger.")
-    print(f"      If no x-ms-notification and no x-ms-notification-content → it's a polling trigger.")
-    print(f"      Default recurrence: every 3 minutes. Ask user if they want to change it.")
+    print("\n  ℹ️  Check Swagger for this operation to determine if it's a recurrence trigger.")
+    print("      If no x-ms-notification and no x-ms-notification-content → it's a polling trigger.")
+    print("      Default recurrence: every 3 minutes. Ask user if they want to change it.")
 
 # =========================================================================
 # Step 2: Create Access Policy + RBAC (required before trigger creation)
@@ -237,10 +239,10 @@ assignment_name = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{gw_principal_id}-{sandbo
 role_url = f"https://management.azure.com{sg_scope}/providers/Microsoft.Authorization/roleAssignments/{assignment_name}?api-version=2022-04-01"
 try:
     az_rest("PUT", role_url, body=role_body)
-    print(f"  ✓ RBAC role assigned: gateway MI → sandbox group")
+    print("  ✓ RBAC role assigned: gateway MI → sandbox group")
 except subprocess.CalledProcessError as e:
     if "RoleAssignmentExists" in (e.stderr or ""):
-        print(f"  ✓ RBAC role already exists")
+        print("  ✓ RBAC role already exists")
     else:
         print(f"  ⚠️  RBAC assignment failed (trigger may 403): {e.stderr[:200] if e.stderr else 'unknown error'}")
 
@@ -282,7 +284,11 @@ trigger_body = {
                 "activationMode": "OnDemand",
                 "command": f"echo 'Trigger {config_name} fired!' >> /tmp/trigger.log",
             },
-            "callbackUrl": f"https://management.azuredevcompute.io/subscriptions/{subscription_id}/resourceGroups/{rg}/sandboxGroups/{sandbox_group}/sandboxes/{sandbox_id}/executeShellCommand?api-version=2026-02-01-preview",
+            "callbackUrl": (
+                f"https://management.azuredevcompute.io/subscriptions/{subscription_id}"
+                f"/resourceGroups/{rg}/sandboxGroups/{sandbox_group}/sandboxes/{sandbox_id}"
+                "/executeShellCommand?api-version=2026-02-01-preview"
+            ),
             "httpMethod": "Post",
         },
         "operationName": selected_name,
@@ -330,7 +336,7 @@ if args.cleanup:
     az_rest("DELETE", f"{ARM_BASE}/triggerConfigs/{config_name}?{API_VERSION}")
     print(f"  ✓ Deleted trigger config: {config_name}")
 else:
-    print(f"\n  Trigger left running. Pass --cleanup to delete.")
+    print("\n  Trigger left running. Pass --cleanup to delete.")
 
 print("\nDone!")
 

--- a/plugin/skills/aca-sandboxes/scripts/trigger-getting-started.py
+++ b/plugin/skills/aca-sandboxes/scripts/trigger-getting-started.py
@@ -254,6 +254,16 @@ print("Step 3: Create Trigger Config")
 print("=" * 60)
 config_name = f"{connector}-trigger"
 
+# Sandbox data-plane endpoints are regional (management.{region}.azuredevcompute.io),
+# NOT management.azuredevcompute.io — using the unregional host causes a 404
+# GlobalSandboxNotFound when the trigger fires. See gotchas.md and trigger-setup.md.
+sandbox_group_url = (
+    f"https://management.azure.com/subscriptions/{subscription_id}"
+    f"/resourceGroups/{rg}/providers/Microsoft.App/sandboxGroups/{sandbox_group}"
+    "?api-version=2026-02-01-preview"
+)
+sandbox_region = az_rest("GET", sandbox_group_url).get("location", location)
+
 # Build connector-aware default parameters
 DEFAULT_PARAMS = {
     "office365": [{"name": "folderPath", "value": "Inbox"}],
@@ -285,7 +295,7 @@ trigger_body = {
                 "command": f"echo 'Trigger {config_name} fired!' >> /tmp/trigger.log",
             },
             "callbackUrl": (
-                f"https://management.azuredevcompute.io/subscriptions/{subscription_id}"
+                f"https://management.{sandbox_region}.azuredevcompute.io/subscriptions/{subscription_id}"
                 f"/resourceGroups/{rg}/sandboxGroups/{sandbox_group}/sandboxes/{sandbox_id}"
                 "/executeShellCommand?api-version=2026-02-01-preview"
             ),

--- a/public-preview/connector-namespace-cli/install.ps1
+++ b/public-preview/connector-namespace-cli/install.ps1
@@ -1,4 +1,4 @@
-# Install (or uninstall) the `az connector-namespace` Azure CLI extension.
+﻿# Install (or uninstall) the `az connector-namespace` Azure CLI extension.
 #
 # Usage:
 #   # Default: install the latest published wheel (https://aka.ms/connector-namespace.whl)

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,7 +5,7 @@
 # hardcoded secrets, unsafe deserialization, etc.), since this repo's
 # security-baseline audit calls for both style and security coverage.
 line-length = 150
-target-version = "py311"
+target-version = "py310"
 
 [lint]
 select = ["E", "F", "S"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,11 @@
+# Ruff configuration for connector automation scripts.
+#
+# Selects pycodestyle/pyflakes (E, F) for style/error checks plus
+# flake8-bandit (S) for security-relevant patterns (subprocess use,
+# hardcoded secrets, unsafe deserialization, etc.), since this repo's
+# security-baseline audit calls for both style and security coverage.
+line-length = 150
+target-version = "py311"
+
+[lint]
+select = ["E", "F", "S"]


### PR DESCRIPTION
## Summary

Closes the CodeQL-Python and CI-lint gaps identified during the repo security-baseline audit.

## Changes

- **codeql.yml**: add `python` to the language matrix. Python is this repo's dominant language (14,338 bytes) but had zero CodeQL coverage - the matrix only ever scanned `actions`.
- **lint.yml** (new): three lint gates - ShellCheck is preinstalled on the runner; PSScriptAnalyzer and ruff are installed at pinned versions from their official registries (PowerShell Gallery, pip), so there's no third-party Action requiring SHA-pinning:
  - `ShellCheck` against all `*.sh` files
  - `PSScriptAnalyzer` (pinned to 1.25.0) against all `*.ps1` files (`Warning`+`Error` severity)
  - `ruff` (pinned to 0.15.14) against all Python files, selecting both style (`E`, `F`) and security (`S` / flake8-bandit) rules
- **ruff.toml** (new): `line-length = 150`, `target-version = "py310"` (matches this script's documented Python 3.10+ minimum), `select = ["E", "F", "S"]`.
- **PSScriptAnalyzerSettings.psd1** (new): excludes `PSAvoidUsingWriteHost` repo-wide, since `install.ps1` is an interactive `irm | iex` installer where console-only output is intentional.
- **trigger-getting-started.py**: fixes required to pass the new ruff gate cleanly, plus one real bug found by Copilot review:
  - Removed extraneous `f` prefixes from 6 f-strings with no placeholders (`F541`).
  - Wrapped one 224-character callback-URL f-string across multiple lines.
  - Added justified `# noqa: S603` / `# noqa: S607` comments on the 4 `subprocess.run` calls to `az` - all use fixed argument lists (never `shell=True`, never untrusted/interpolated input), so these are not injection risks.
  - **Bug fix (from Copilot review):** the trigger `callbackUrl` used the unregional `management.azuredevcompute.io` host, which 404s (`GlobalSandboxNotFound`) per this repo's own `gotchas.md`/`trigger-setup.md`. Now fetches the sandbox group's ARM location and builds a regional `management.{region}.azuredevcompute.io` host instead. The `audience` field is intentionally left unregional, matching the documented canonical pattern.
- **install.ps1**: added a UTF-8 BOM (encoding-only change, no functional change) to resolve `PSUseBOMForUnicodeEncodedFile`.

## Validation

All three lint tools were run locally against the affected files before pushing, and the PR's own CI (CodeQL actions+python, Lint/ShellCheck, Lint/PSScriptAnalyzer, Lint/Ruff) is green:
- `ruff check .` -> all checks passed (including after the py310 target-version fix)
- `Invoke-ScriptAnalyzer -Settings PSScriptAnalyzerSettings.psd1` -> zero findings
- Shell scripts were manually reviewed; they already use `set -euo pipefail`/`set -eu` and consistently quote variables - confirmed clean by the CI ShellCheck job.

Went through two rounds of Copilot review: round 1 caught the regional-host bug above; round 2 caught the unpinned tool versions and an inaccurate header comment (all fixed). Round 3 was a clean pass.