### PR TITLE
Register MCP Connectors canvas in marketplace

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -18,6 +18,12 @@
         "./skills/connectors",
         "./skills/aca-sandboxes"
       ]
+    },
+    {
+      "name": "connector-namespaces",
+      "source": "./connector-namespaces",
+      "description": "Interactive GitHub Copilot canvas for discovering, connecting, and managing hosted MCP servers from an Azure Connector Namespace.",
+      "version": "1.2.0"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Registers the existing `connector-namespaces` canvas plugin in the root `marketplace.json` catalog.

The plugin and its `1.2.0` manifest already live under `connector-namespaces/`, but the marketplace currently exposes only `azure-connectornamespace`. As a result, users can add `Azure/Connectors` successfully but receive `Plugin "connector-namespaces" not found` when they try to install the canvas.

## Linked issue

Unblocks github/awesome-copilot#2401.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Other:

## Validation

- Parsed `marketplace.json` and verified unique plugin names.
- Verified the catalog name, version, and source match `connector-namespaces/.github/plugin/plugin.json`.
- With an isolated `COPILOT_HOME`, added the local marketplace, browsed `Azure-Connectors`, and installed `connector-namespaces@Azure-Connectors` successfully.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Tests added or updated (if applicable)
- [x] Documentation updated (if applicable; no documentation change needed)
- [x] No secrets, PII, or customer data in commits